### PR TITLE
Skip downloading if file already exists

### DIFF
--- a/doc/axelrc.example
+++ b/doc/axelrc.example
@@ -113,3 +113,10 @@
 # a scp-alike interface.
 #
 # alternate_output = 1
+
+# If you want to skip downloading files with same names. Normally, axel will
+# add .<number> to the name of the file in cases that file already exists.
+# With no_clobber option, axel will skip downloading this file altogether.
+#
+# no_clobber = 1
+#

--- a/src/conf.c
+++ b/src/conf.c
@@ -135,6 +135,7 @@ int conf_loadfile( conf_t *conf, char *file )
 		/* Numeric options */
 	num_keys:
 		MATCH
+			KEY( no_clobber )
 			KEY( strip_cgi_parameters )
 			KEY( save_state_interval )
 			KEY( connection_timeout )
@@ -197,6 +198,7 @@ int conf_init( conf_t *conf )
 	strcpy( conf->default_filename, "default" );
 	*conf->http_proxy		= 0;
 	*conf->no_proxy			= 0;
+	conf->no_clobber		= 1;
 	conf->strip_cgi_parameters	= 1;
 	conf->save_state_interval	= 10;
 	conf->connection_timeout	= 45;

--- a/src/conf.h
+++ b/src/conf.h
@@ -45,6 +45,7 @@ typedef struct
 	char default_filename[MAX_STRING];
 	char http_proxy[MAX_STRING];
 	char no_proxy[MAX_STRING];
+	int no_clobber;
 	int strip_cgi_parameters;
 	int save_state_interval;
 	int connection_timeout;


### PR DESCRIPTION
If you want to skip downloading files with same names. Normally, axel will add `.{number}` to the name of the file in cases that file already exists. With `--no-clobber` (`-c`) option, axel will skip downloading this file altogether.

* axel-download-accelerator/axel#37