### PR TITLE
Add --no-clobber option

### DIFF
--- a/doc/axelrc.example
+++ b/doc/axelrc.example
@@ -113,3 +113,11 @@
 # a scp-alike interface.
 #
 # alternate_output = 1
+#
+# Set this to 1 to avoid axel to download a file if one with the same name
+# already exists in the current folder and no state file is found.
+# Normally, axel will add .<number> to the name of the file in cases where
+# that file already exists. With the no_clobber option, axel will skip
+# downloading this file altogether.
+#
+# no_clobber = 1

--- a/man/axel.1
+++ b/man/axel.1
@@ -77,6 +77,8 @@ is active somewhere, of course.
 \fB--insecure\fP, \fB-k\fP
 Do not verify the SSL certificate. Only use this if you are getting certificate errors
 and you are sure of the sites authenticity.
+.PP
+\fB--no-clobber\fP, \fB-c\fP Skip download if a file with the same name already exists in the current folder and no state file is found.
 .TP
 .B
 \fB--verbose\fP, \fB-v\fP

--- a/man/axel.txt
+++ b/man/axel.txt
@@ -53,6 +53,8 @@ OPTIONS
  --insecure, -k  Do not verify the SSL certificate. Only use this if you are getting certificate errors
                  and you are sure of the sites authenticity.
 
+ --no-clobber, -c Skip download if a file with the same name already exists in the current folder and no state file is found.
+
  --verbose, -v  Show more status messages. Use it more than once to see more details.
 
  --quiet, -q  No output to stdout.

--- a/src/axel.c
+++ b/src/axel.c
@@ -152,6 +152,25 @@ axel_t *axel_new( conf_t *conf, int count, const void *url )
 	if( ( s = strchr( axel->filename, '?' ) ) != NULL && axel->conf->strip_cgi_parameters )
 		*s = 0;		/* Get rid of CGI parameters */
 
+	if( axel->conf->no_clobber && access( axel->filename, F_OK ) == 0 )
+	{
+		char stfile[MAX_STRING + 3];
+
+		sprintf( stfile, "%s.st", axel->filename );
+		if( access( stfile, F_OK ) == 0 )
+		{
+			printf( _("Incomplete download found, ignoring "
+				  "no-clobber option\n") );
+		}
+		else
+		{
+			printf( _("File '%s' already there; not retrieving.\n"),
+				axel->filename );
+			axel->ready = -1;
+			return( axel );
+		}
+	}
+
 	do
 	{
 		if( !conn_init( &axel->conn[0] ) )

--- a/src/conf.c
+++ b/src/conf.c
@@ -146,6 +146,7 @@ int conf_loadfile( conf_t *conf, char *file )
 			KEY( verbose )
 			KEY( alternate_output )
 			KEY( insecure )
+			KEY( no_clobber )
 			KEY( search_timeout )
 			KEY( search_threads )
 			KEY( search_amount )
@@ -208,6 +209,7 @@ int conf_init( conf_t *conf )
 	conf->verbose			= 1;
 	conf->alternate_output		= 0;
 	conf->insecure			= 0;
+	conf->no_clobber		= 0;
 
 	conf->search_timeout		= 10;
 	conf->search_threads		= 3;

--- a/src/conf.h
+++ b/src/conf.h
@@ -56,6 +56,7 @@ typedef struct
 	int verbose;
 	int alternate_output;
 	int insecure;
+	int no_clobber;
 
 	if_t *interfaces;
 

--- a/src/text.c
+++ b/src/text.c
@@ -76,6 +76,7 @@ static struct option axel_options[] =
 	{ "version",		0,	NULL,	'V' },
 	{ "alternate",		0,	NULL,	'a' },
 	{ "insecure", 		0,	NULL,	'k' },
+	{ "no-clobber",		0,	NULL,	'c' },
 	{ "header",		1,	NULL,	'H' },
 	{ "user-agent",		1,	NULL,	'U' },
 	{ NULL,			0,	NULL,	0 }
@@ -113,7 +114,7 @@ int main( int argc, char *argv[] )
 	{
 		int option;
 
-		option = getopt_long( argc, argv, "s:n:o:S::46NqvhVakH:U:", axel_options, NULL );
+		option = getopt_long( argc, argv, "s:n:o:S::46NqvhVakcH:U:", axel_options, NULL );
 		if( option == -1 )
 			break;
 
@@ -169,6 +170,9 @@ int main( int argc, char *argv[] )
 			break;
 		case 'k':
 			conf->insecure = 1;
+			break;
+		case 'c':
+			conf->no_clobber = 1;
 			break;
 		case 'N':
 			*conf->http_proxy = 0;
@@ -642,6 +646,7 @@ void print_help()
 		"-U x\tSet user agent\n"
 		"-N\tJust don't use any proxy server\n"
 		"-k\tDon't verify the SSL certificate\n"
+		"-c\tSkip download if file already exists\n"
 		"-q\tLeave stdout alone\n"
 		"-v\tMore status information\n"
 		"-a\tAlternate progress indicator\n"
@@ -663,6 +668,7 @@ void print_help()
 		"--user-agent=x\t\t-U x\tSet user agent\n"
 		"--no-proxy\t\t-N\tJust don't use any proxy server\n"
 		"--insecure\t\t-k\tDon't verify the SSL certificate\n"
+		"--no-clobber\t\t-c\tSkip download if file already exists\n"
 		"--quiet\t\t\t-q\tLeave stdout alone\n"
 		"--verbose\t\t-v\tMore status information\n"
 		"--alternate\t\t-a\tAlternate progress indicator\n"


### PR DESCRIPTION
Like wget, when the --no-clobber option is specified, skip
download if a file with the same name already exists in the
current directory.

Closes: https://github.com/axel-download-accelerator/axel/issues/37
Signed-off-by: Antonio Quartulli <a@unstable.cc>

This PR supersedes PR #94 .