### PR TITLE
Rename constants from OpenSSL to SSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,19 +34,19 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_CHECK_FUNCS([malloc realloc gettimeofday inet_ntoa memset select setlocale socket strncasecmp strchr strrchr strstr])
 
-# Optional (but included-by-default) openssl support
-AC_ARG_WITH([openssl],
-    AC_HELP_STRING([--without-openssl],[disable TLS support]), [], [with_openssl=yes])
+# Optional (but included-by-default) ssl support
+AC_ARG_WITH([ssl],
+    AC_HELP_STRING([--without-ssl],[disable TLS support]), [], [with_ssl=yes])
 
-AS_IF([test "x$with_openssl" != xno], [
-    AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL])
+AS_IF([test "x$with_ssl" != xno], [
+    AC_DEFINE([HAVE_SSL], [1], [SSL])
     AC_SEARCH_LIBS([SSL_new], [ssl], [], [
         AC_MSG_ERROR([libssl not found])
     ])
     AC_SEARCH_LIBS([ERR_get_error], [crypto], [], [
         AC_MSG_ERROR([libcrypto not found])
     ])
-], AC_MSG_NOTICE([OpenSSL support disabled]))
+], AC_MSG_NOTICE([SSL support disabled]))
 
 # Add Gettext
 AM_GNU_GETTEXT([external])

--- a/src/axel.h
+++ b/src/axel.h
@@ -72,7 +72,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <pthread.h>
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 #include <openssl/ssl.h>
 #endif
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -72,7 +72,7 @@ int conn_set( conn_t *conn, const char *set_url )
 			conn->proto = PROTO_HTTP;
 			conn->port = PROTO_HTTP_PORT;
 		}
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 		else if( strncmp( set_url, "ftps", proto_len ) == 0 )
 		{
 			conn->proto = PROTO_FTPS;
@@ -83,7 +83,7 @@ int conn_set( conn_t *conn, const char *set_url )
 			conn->proto = PROTO_HTTPS;
 			conn->port = PROTO_HTTPS_PORT;
 		}
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 		else
 		{
 			return( 0 );

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37,7 +37,7 @@
 
 #include "axel.h"
 
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 
 #include <openssl/err.h>
 
@@ -98,4 +98,4 @@ void ssl_disconnect( SSL *ssl )
 	SSL_free( ssl );
 }
 
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -37,12 +37,12 @@
 #ifndef AXEL_SSL_H
 #define AXEL_SSL_H
 
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 
 void ssl_init( conf_t *conf );
 SSL* ssl_connect( int fd, char *hostname, char *message );
 void ssl_disconnect( SSL *ssl );
 
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 
 #endif /* AXEL_SSL_H */

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -118,7 +118,7 @@ int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_i
 		return -1;
 	}
 
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 	if (secure) {
 		tcp->ssl = ssl_connect(sock_fd, hostname, message);
 		if (tcp->ssl == NULL) {
@@ -126,7 +126,7 @@ int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_i
 			return -1;
 		}
 	}
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 	tcp->fd = sock_fd;
 
 	return 1;
@@ -134,35 +134,35 @@ int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_i
 
 int tcp_read( tcp_t *tcp, void *buffer, int size )
 {
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 	if (tcp->ssl != NULL)
 		return SSL_read(tcp->ssl, buffer, size);
 	else
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 		return read(tcp->fd, buffer, size);
 }
 
 int tcp_write( tcp_t *tcp, void *buffer, int size )
 {
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 	if (tcp->ssl != NULL)
 		return SSL_write(tcp->ssl, buffer, size);
 	else
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 		return write(tcp->fd, buffer, size);
 }
 
 void tcp_close( tcp_t *tcp )
 {
 	if (tcp->fd > 0) {
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 		if (tcp->ssl != NULL)
 		{
 			ssl_disconnect(tcp->ssl);
 			tcp->ssl = NULL;
 		}
 		else
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 			close(tcp->fd);
 		tcp->fd = -1;
 	}

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -41,7 +41,7 @@
 typedef struct {
 	int fd;
 	sa_family_t ai_family;
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 	SSL *ssl;
 #endif
 } tcp_t;

--- a/src/text.c
+++ b/src/text.c
@@ -225,9 +225,9 @@ int main( int argc, char *argv[] )
 		return( 1 );
 	}
 
-#ifdef HAVE_OPENSSL
+#ifdef HAVE_SSL
 	ssl_init( conf );
-#endif /* HAVE_OPENSSL */
+#endif /* HAVE_SSL */
 
 	if( argc - optind == 0 )
 	{


### PR DESCRIPTION
As a first step towards making the code libssl generic,
rename all the constants (including strings in configure.ac)
from OpenSSL to SSL only.

Signed-off-by: Antonio Quartulli <a@unstable.cc>