### PR TITLE
Update axel.h

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -80,7 +80,7 @@
 #endif
 
 /* Compiled-in settings */
-#define MAX_STRING		1024
+#define MAX_STRING		10240
 #define MAX_ADD_HEADERS	10
 #define MAX_REDIRECT		20
 #define DEFAULT_IO_TIMEOUT	120


### PR DESCRIPTION
When I use Axel to download file from Baiduyun(an online file disk in China),it says me The URL is above 1024, so I Increase the Max URL length to support URL longer than 1024. Thank you.