### PR TITLE
Fix composition of relative URLs in redirections 

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -341,14 +341,14 @@ conn_info(conn_t *conn)
 			if ((t = http_header(conn->http, "location:")) == NULL)
 				return 0;
 			sscanf(t, "%1000s", s);
-			if (strstr(s, "://") == NULL) {
-				sprintf(conn->http->headers, "%s%s",
-					conn_url(conn), s);
+			if (strstr(s, "://") != NULL) {
+				sprintf(conn->http->headers, "%s", s);
 				strncpy(s, conn->http->headers, sizeof(s) - 1);
 				s[sizeof(s) - 1] = '\0';
 			} else if (s[0] == '/') {
-				sprintf(conn->http->headers, "http://%s:%i%s",
-					conn->host, conn->port, s);
+				sprintf(conn->http->headers, "%s%s:%i%s",
+					scheme_from_proto(conn->proto), 
+						conn->host, conn->port, s);
 				strncpy(s, conn->http->headers, sizeof(s) - 1);
 				s[sizeof(s) - 1] = '\0';
 			}


### PR DESCRIPTION
Fixes: [Issue #144](https://github.com/axel-download-accelerator/axel/issues/144)

The issue seems to be axel appending the redirected path to the complete
url of the previous request instead of just the hostname. This has been
fixed in this commit

**Bug Example:**
Request Header by Axel:
```
GET /download/2.0.1/tarball/ HTTP/1.0
Host: www.djangoproject.com
Accept: */*
Range: bytes=1-
User-Agent: Axel/2.16.1 (Linux)
```
Response Header:
```
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 06 Feb 2018 09:39:45 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: close
Content-Language: en
Location: /m/releases/2.0/Django-2.0.1.tar.gz
```
Request to Redirected URL by Axel:
```
GET /download/2.0.1/tarball//m/releases/2.0/Django-2.0.1.tar.gz HTTP/1.0
Host: www.djangoproject.com
Accept: */*
Range: bytes=1-
User-Agent: Axel/2.16.1 (Linux)
```