### PR TITLE
Add snap packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: axel
+version: '2.16.1'
+version-script: cat VERSION | cut -d ' ' -f1
+summary: Light command line download accelerator
+description: |
+  Light command line download accelerator
+
+grade: devel
+confinement: strict
+
+parts:
+  axel:
+    plugin: autotools
+    source: .
+    build-packages:
+      - autoconf
+      - pkg-config
+      - gettext
+      - autopoint
+      - libssl-dev
+
+apps:
+  axel:
+    command: axel
+    plugs:
+      - network
+      - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,27 +1,43 @@
 name: axel
-version: '2.16.1'
-version-script: cat VERSION | cut -d ' ' -f1
+version: 'latest'
+version-script: cat $SNAPCRAFT_STAGE/VERSION | cut -d ' ' -f1
 summary: Light command line download accelerator
 description: |
   Light command line download accelerator
-
-grade: stable
+grade: devel
 confinement: strict
 
 parts:
   axel:
-    plugin: autotools
-    source: .
+    plugin: nil
+    override-build: |
+      snapcraftctl build
+      URL=$(curl https://api.github.com/repos/axel-download-accelerator/axel/releases/latest -s | jq .zipball_url -r)
+      wget $URL -O release.zip
+      unzip release.zip -d release
+      cd release/*
+      autoreconf -fiv
+      ./configure --prefix=$PWD/build_dir; make; make install build_dir
+      mv build_dir/* ${SNAPCRAFT_PART_INSTALL}
+      mv VERSION $SNAPCRAFT_STAGE/
+      cd ../../
+      rm -r release.zip release
     build-packages:
+      - curl
+      - jq
+      - wget
+      - unzip
       - autoconf
       - pkg-config
       - gettext
       - autopoint
       - libssl-dev
+    stage-packages:
+      - libssl1.1
 
 apps:
   axel:
-    command: axel
+    command: bin/axel
     plugs:
       - network
       - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ summary: Light command line download accelerator
 description: |
   Light command line download accelerator
 
-grade: devel
+grade: stable
 confinement: strict
 
 parts:


### PR DESCRIPTION
This PR adds snap packaging. A ‘snap’ is a universal Linux package, more reading here https://www.ubuntu.com/desktop/snappy

Once this PR is landed, we can setup automatic builds using https://build.snapcraft.io, once setup, for every new commit to master of this project, a new snap build kicks in and is released to the "edge" (or nightly) channel.

Note: I commit to the maintenance of axel as a snap package, so should there an issue arrive, I'll fix that.