### PR TITLE
Add support for IPv6 literal hostname in url

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -144,21 +144,30 @@ http_disconnect(http_t *conn)
 void
 http_get(http_t *conn, char *lurl)
 {
+	char * prefix = "";
+	char * postfix = "";
+	// If host is ipv6 literal add square brackets
+	if (is_ipv6_addr(conn->host)) {
+		prefix = "[";
+		postfix = "]";
+	}
+
 	*conn->request = 0;
 	if (conn->proxy) {
 		const char *proto = scheme_from_proto(conn->proto);
-		http_addheader(conn, "GET %s%s%s HTTP/1.0", proto, conn->host,
-			       lurl);
+		http_addheader(conn, "GET %s%s%s%s%s HTTP/1.0", proto,
+					prefix, conn->host, postfix, lurl);
 	} else {
 		http_addheader(conn, "GET %s HTTP/1.0", lurl);
 		if ((conn->proto == PROTO_HTTP &&
 		     conn->port != PROTO_HTTP_PORT) ||
 		    (conn->proto == PROTO_HTTPS &&
 		     conn->port != PROTO_HTTPS_PORT))
-			http_addheader(conn, "Host: %s:%i", conn->host,
-				       conn->port);
+			http_addheader(conn, "Host: %s%s%s:%i", prefix,
+				       conn->host, postfix, conn->port);
 		else
-			http_addheader(conn, "Host: %s", conn->host);
+			http_addheader(conn, "Host: %s%s%s", prefix,
+					conn->host, postfix);
 	}
 	if (*conn->auth)
 		http_addheader(conn, "Authorization: Basic %s", conn->auth);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -47,6 +47,20 @@
 #include <netdb.h>
 #include <sys/ioctl.h>
 
+/*
+ * Check if the given hostname is ipv6 literal
+ * Returns 1 if true and 0 if false
+ */
+int is_ipv6_addr(const char *hostname) {
+	if (!hostname)
+		return 0;
+
+	char buf[16]; //Max buff size needed for inet_pton()
+
+	if (inet_pton(AF_INET6, hostname, buf))
+		return 1;
+	return 0;
+}
 
 static void
 tcp_error(char *buffer, char *hostname, int port, const char *reason)

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -52,6 +52,7 @@ typedef struct {
 #endif
 } tcp_t;
 
+int is_ipv6_addr(const char *hostname);
 int tcp_connect(tcp_t *tcp, char *hostname, int port, int secure,
 		char *local_if, char *message, unsigned io_timeout);
 void tcp_close(tcp_t *tcp);


### PR DESCRIPTION
### Commit [bfd6e88](https://github.com/axel-download-accelerator/axel/pull/181/commits/bfd6e881c468bf194222a5e05a59de0b7dbfa7fa):
Axel was previously unable to parse ipv6 address as hostname of url.
This has been fixed, conforming to RFC 2732

Closes #169 

### Commit [8de7c1a](https://github.com/axel-download-accelerator/axel/pull/181/commits/8de7c1af2c27f8492aa08b437cbeb23c505b231a):
Axel did not add port number to the absolute url in the GET request to the proxy if it is not the default port. This has been fixed in this commit.

@ismaell please review my pull requests.