### PR TITLE
range offset calculation fix in axel_divide

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -835,8 +835,11 @@ axel_divide(axel_t *axel)
 {
 	int i;
 
+    if (axel->conf->num_connections > axel->size)
+        axel->conf->num_connections = axel->size;
+
 	axel->conn[0].currentbyte = 0;
-	axel->conn[0].lastbyte = axel->size / axel->conf->num_connections - 1;
+	axel->conn[0].lastbyte = (axel->size / axel->conf->num_connections) - 1 + (axel->size % axel->conf->num_connections);
 	for (i = 1; i < axel->conf->num_connections; i++) {
 #ifdef DEBUG
 		printf(_("Downloading %lld-%lld using conn. %i\n"),
@@ -846,9 +849,8 @@ axel_divide(axel_t *axel)
 		axel->conn[i].currentbyte = axel->conn[i - 1].lastbyte + 1;
 		axel->conn[i].lastbyte =
 		    axel->conn[i].currentbyte +
-		    axel->size / axel->conf->num_connections;
+		    (axel->size / axel->conf->num_connections) - 1;
 	}
-	axel->conn[axel->conf->num_connections - 1].lastbyte = axel->size - 1;
 #ifdef DEBUG
 	printf(_("Downloading %lld-%lld using conn. %i\n"),
 	       axel->conn[i - 1].currentbyte, axel->conn[i - 1].lastbyte,


### PR DESCRIPTION
1) the logic to calculate the offsets of currentbyte and lastbyte is buggy. There is no concept of stopping the calculation of the offsets and it goes beyond the filesize. 

filesize = 107, num connections = 20

Downloading 0-4 using conn. 0
Downloading 5-10 using conn. 1
Downloading 11-16 using conn. 2
Downloading 17-22 using conn. 3
Downloading 23-28 using conn. 4
Downloading 29-34 using conn. 5
Downloading 35-40 using conn. 6
Downloading 41-46 using conn. 7
Downloading 47-52 using conn. 8
Downloading 53-58 using conn. 9
Downloading 59-64 using conn. 10
Downloading 65-70 using conn. 11
Downloading 71-76 using conn. 12
Downloading 77-82 using conn. 13
Downloading 83-88 using conn. 14
Downloading 89-94 using conn. 15
Downloading 95-100 using conn. 16
Downloading 101-106 using conn. 17
**Downloading 107-112 using conn. 18  (range beyond filesize)**
**Downloading 113-106 using conn. 19 (range beyond filesize)**

with fix:

Downloading 0-11 using conn. 0
Downloading 12-16 using conn. 1
Downloading 17-21 using conn. 2
Downloading 22-26 using conn. 3
Downloading 27-31 using conn. 4
Downloading 32-36 using conn. 5
Downloading 37-41 using conn. 6
Downloading 42-46 using conn. 7
Downloading 47-51 using conn. 8
Downloading 52-56 using conn. 9
Downloading 57-61 using conn. 10
Downloading 62-66 using conn. 11
Downloading 67-71 using conn. 12
Downloading 72-76 using conn. 13
Downloading 77-81 using conn. 14
Downloading 82-86 using conn. 15
Downloading 87-91 using conn. 16
Downloading 92-96 using conn. 17
Downloading 97-101 using conn. 18
Downloading 102-106 using conn. 19