### PR TITLE
Define _DARWIN_C_SOURCE on macOS

### DIFF
--- a/src/sleep.h
+++ b/src/sleep.h
@@ -5,6 +5,10 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 static inline int
 axel_sleep(struct timespec delay)
 {

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -39,6 +39,9 @@
 /* TCP control file */
 
 #define _POSIX_C_SOURCE 200112L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
 
 #include "axel.h"
 


### PR DESCRIPTION
Fixes #136.

This is necessary alongside `_POSIX_C_SOURCE` in order to get all of the expected things. This should only be necessary on Darwin, and is always needed there, so this feels like the easiest way to add the `#define` in the same place as `_POSIX_C_SOURCE`.