### PR TITLE
BUGFIX: Sanitize the param passed to memset

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -566,7 +566,7 @@ print_alternate_output_progress(axel_t *axel, char *progress, int width,
 				progress[offset] = '#';
 		}
 		memset(progress + offset + 1, ' ',
-		       axel->conn[i].lastbyte * width / total - offset - 1);
+		       max(0, axel->conn[i].lastbyte * width / total - offset - 1));
 	}
 
 	progress[width] = '\0';


### PR DESCRIPTION
The param passed to **memset** will be caculated to "-1", which will cause "Segmentation fault".
We need sanitize the parameter here.

![image](https://user-images.githubusercontent.com/11314597/57583521-9d8b1400-7503-11e9-97a3-9b2cc5c16761.png)

Signed-off-by: Kun Ma <kun.ma@citrix.com>