### PR TITLE
Added INSTALL to distclean-local

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ distclean-local:
 	config.* \
 	configure \
 	depcomp \
+	INSTALL \
 	install-sh \
 	Makefile.in \
 	missing \


### PR DESCRIPTION
The Makefile.am should have 'INSTALL' inside distclean-local. INSTALL is a auto-generated file and shound not be distributed in source code. 