### PR TITLE
Fix progress indicator misalignment in some cases

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -403,7 +403,7 @@ main(int argc, char *argv[])
 				print_alternate_output(axel);
 		} else {
 			/* The infamous wget-like 'interface'.. ;) */
-			size_t done = (axel->bytes_done - prev) / 1024;
+			size_t done = (axel->bytes_done / 1024) - (prev / 1024);
 			if (done && conf->verbose > -1) {
 				for (size_t i = 0; i < done; i++) {
 					i += (prev / 1024);


### PR DESCRIPTION
The issue is evident when fetching over HTTP/FTP (HTTPS much less so):

    $ axel http://speed.hetzner.de/1GB.bin
    Initializing download: http://speed.hetzner.de/1GB.bin
    File size: 1048576000 bytes
    Opening output file 1GB.bin
    Starting download

    [  0%]  .......... .......... .......... .......... ..........  [
    290.7KB/s]
    [  0%]  .......... .......... .......... .......... ..........  [
    512.6KB/s]
    [  0%]  .......... .......... .......... ......... ........  [
    727.7KB/s]
    [  0%]  ........ ....... .......... ..................  [ 825.2KB/s]
    [  0%]  ................. ....... ........ .......  [ 958.2KB/s]
    [  0%]  ....... ............... ......... ..........................
    ......... ......... .......  [1176.6KB/s]
    [  0%]  ......... ....... .......................  [1303.1KB/s]
    [  0%]  ........ ........ ....... ....... .........  [1426.3KB/s]
    [  0%]  ........ ..............................  [1542.4KB/s]
    [  0%]  ....... ....... ....... ........ .........  [1636.9KB/s]
    [  0%]  ......... ........ ................ ........  [1745.8KB/s]

Fixes: ef6ccfc4a38f ("More type-related fixes")
Fixes: https://github.com/axel-download-accelerator/axel/issues/228
Signed-off-by: Evangelos Foutras <evangelos@foutrelis.com>