### PR TITLE
Fix basic auth credentials generating algorithm

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -72,8 +72,10 @@ http_auth_token(char *token, const char *user, const char *pass)
 	const char *auth[] = { user, ":", pass, NULL };
 	const char **p = auth;
 
-	while (*p && **p) {
+	while (*p) {
 		char a = chain_next(&p);
+		if (!a)
+			break;
 		*token++ = base64_encode[a >> 2];
 		char b = chain_next(&p);
 		*token++ = base64_encode[((a & 3) << 4) | (b >> 4)];


### PR DESCRIPTION
base64 encoded authorization credentials are generated incorrectly for
certain username and password. fixed in this commit

Fixes: #216

Signed-off-by: Shankar <shankar_m@protonmail,com>