### PR TITLE
doc: Fix usage of date command

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -11,7 +11,7 @@ PACKAGE_DESC = lightweight command line download accelerator
 	tmp=$$(mktemp tmpXXXXXX) && \
 	> "$$tmp" \
 	txt2man -t "$(<:.txt=)" -s 1 \
-		-d "$$(date -d"$$P_DATE" '+%B %_d, %Y')" \
+		-d "$$(date -d "$$P_DATE" '+%B %_d, %Y')" \
 		-P "$(PACKAGE_NAME)" \
 		-r "$(PACKAGE_NAME)-$(PACKAGE_VERSION)" \
 		-v "$(PACKAGE_DESC)" $< &&\


### PR DESCRIPTION
Add a space between argument and date's -d flag, breaks on BSD.