### PR TITLE
tcp: explicitly close sockets on SSL connections too

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -221,9 +221,9 @@ tcp_close(tcp_t *tcp)
 		if (tcp->ssl != NULL) {
 			ssl_disconnect(tcp->ssl);
 			tcp->ssl = NULL;
-		} else
-#endif				/* HAVE_SSL */
-			close(tcp->fd);
+		}
+#endif
+		close(tcp->fd);
 		tcp->fd = -1;
 	}
 }


### PR DESCRIPTION
ssl_disconnect() does not close sockets, leading to file descriptor leaks.
Program abortions were also observed if users called axel with a lot of
connections to download a big file.

Explicitly call close(2) on SSL connections too.

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>