### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Optional:
 * `gettext`
 * `libssl-dev`
 * `pkg-config`
+* `txt2man`
 
 ### Build instructions ###
 


### PR DESCRIPTION
Project now requires `txt2man` on Ubuntu to build successfully.