### PR TITLE
Fix headers bugs

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -99,7 +99,7 @@ main(int argc, char *argv[])
 	search_t *search;
 	conf_t conf[1];
 	axel_t *axel;
-	int j, cur_head = 0, ret = 1;
+	int j, ret = 1;
 	char *s;
 
 	fn[0] = 0;
@@ -131,7 +131,7 @@ main(int argc, char *argv[])
 				      "User-Agent", optarg);
 			break;
 		case 'H':
-			strlcpy(conf->add_header[cur_head++], optarg,
+			strlcpy(conf->add_header[conf->add_header_count++], optarg,
 				sizeof(conf->add_header[0]));
 			break;
 		case 's':
@@ -213,7 +213,6 @@ main(int argc, char *argv[])
 			goto free_conf;
 		}
 	}
-	conf->add_header_count = cur_head;
 
 	/* disable alternate output and verbosity when quiet is specified */
 	if (conf->verbose < 0)

--- a/src/text.c
+++ b/src/text.c
@@ -131,6 +131,11 @@ main(int argc, char *argv[])
 				      "User-Agent", optarg);
 			break;
 		case 'H':
+			if(!(conf->add_header_count<MAX_ADD_HEADERS)) {
+				fprintf(stderr,
+					_("Too many custom headers (-H)! Currently only %u custom headers can be appended.\n"), MAX_ADD_HEADERS-HDR_count_init);
+				goto free_conf;
+			}
 			strlcpy(conf->add_header[conf->add_header_count++], optarg,
 				sizeof(conf->add_header[0]));
 			break;


### PR DESCRIPTION
Small changes to make sure User-Agent and custom headers all get included in the request. Also a safety check to make sure Axel doesn't write more custom headers to memory than it has space for.

I got rid of the cur_head variable because it didn't seem to be doing anything except for introducing a bug.

fixes #265, fixes #266