### PR TITLE
fixed bug that cut file name string with spaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,10 @@
 # Autoconf for axel
 AC_COPYRIGHT([
-Copyright 2016 Joao Eriberto Mota Filho
-Copyright 2016 Stephen Thirlwall
-Copyright 2017 Antonio Quartulli
-Copyright 2017 Ismael Luceno
-Copyright 2017 Vlad Glagolev
-Copyright 2017 Ismael Luceno
+Copyright 2016      Joao Eriberto Mota Filho
+Copyright 2016      Stephen Thirlwall
+Copyright 2017      Antonio Quartulli
+Copyright 2017-2020 Ismael Luceno
+Copyright 2017      Vlad Glagolev
 
 This file is under the same license as Axel.
 ])

--- a/src/axel.c
+++ b/src/axel.c
@@ -10,8 +10,10 @@
   Copyright 2016      Sjjad Hashemian
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
   Copyright 2017      nemermollon
+  Copyright 2018      Shankar
+  Copyright 2019      Evangelos Foutras
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/axel.h
+++ b/src/axel.h
@@ -7,7 +7,7 @@
   Copyright 2015-2017 Joao Eriberto Mota Filho
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/conf.c
+++ b/src/conf.c
@@ -7,7 +7,8 @@
   Copyright 2016      Ivan Gimenez
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2019      Terry
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/conf.h
+++ b/src/conf.h
@@ -6,7 +6,7 @@
   Copyright 2008      Y Giridhar Appaji Nag
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/conn.c
+++ b/src/conn.c
@@ -9,7 +9,8 @@
   Copyright 2016      Sjjad Hashemian
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2018 Ismael Luceno
+  Copyright 2018      Shankar
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -4,7 +4,8 @@
   Copyright 2001-2007 Wilmer van der Gaast
   Copyright 2007-2008 Y Giridhar Appaji Nag
   Copyright 2016      Stephen Thirlwall
-  Copyright 2017      Ismael Luceno
+  Copyrigth 2017      Antonio Quartulli
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/ftp.h
+++ b/src/ftp.h
@@ -4,7 +4,8 @@
   Copyright 2001-2007 Wilmer van der Gaast
   Copyright 2008      Y Giridhar Appaji Nag
   Copyright 2016      Stephen Thirlwall
-  Copyright 2017      Ismael Luceno
+  Copyright 2017      Antonio Quartulli
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/http.h
+++ b/src/http.h
@@ -7,7 +7,7 @@
   Copyright 2016      Sjjad Hashemian
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/search.c
+++ b/src/search.c
@@ -6,7 +6,7 @@
   Copyright 2010      Philipp Hagemeister
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
   Copyright 2017      Joao Eriberto Mota Filho
 
   This program is free software; you can redistribute it and/or

--- a/src/search.h
+++ b/src/search.h
@@ -2,6 +2,7 @@
   Axel -- A lighter download accelerator for Linux and other Unices
 
   Copyright 2001-2007 Wilmer van der Gaast
+  Copyright 2017      Antonio Quartulli
   Copyright 2017      Ismael Luceno
 
   This program is free software; you can redistribute it and/or

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -1,3 +1,37 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2017 Ismael Luceno
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
 #ifndef AXEL_SLEEP_H
 #define AXEL_SLEEP_H
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4,7 +4,7 @@
   Copyright 2016      Sjjad Hashemian
   Copyright 2016-2017 Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -3,7 +3,7 @@
 
   Copyright 2016-2017 Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -5,7 +5,9 @@
   Copyright 2010      Mark Smith
   Copyright 2016-2017 Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2018      Shankar
+  Copyright 2019      Park Ju Hyung
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -4,7 +4,8 @@
   Copyright 2001-2007 Wilmer van der Gaast
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2018      Shankar
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License

--- a/src/text.c
+++ b/src/text.c
@@ -9,7 +9,10 @@
   Copyright 2016      Mridul Malpotra
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2019      Evangelos Foutras
+  Copyright 2019      Kun Ma
+
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This fixes bug #268.
Allowing spaces inside a file name string, and also delete spaces at both ends of the string.