### PR TITLE
Fix http range error and wrong currentbyte and lastbyte comparsion

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -453,7 +453,7 @@ axel_start(axel_t *axel)
 		axel_message(axel, _("Starting download"));
 
 	for (i = 0; i < axel->conf->num_connections; i++) {
-		if (axel->conn[i].currentbyte > axel->conn[i].lastbyte) {
+		if (axel->conn[i].currentbyte >= axel->conn[i].lastbyte) {
 			pthread_mutex_lock(&axel->conn[i].lock);
 			reactivate_connection(axel, i);
 			pthread_mutex_unlock(&axel->conn[i].lock);
@@ -571,7 +571,7 @@ axel_do(axel_t *axel)
 		if (size == 0) {
 			if (axel->conf->verbose) {
 				/* Only abnormal behaviour if: */
-				if (axel->conn[i].currentbyte <=
+				if (axel->conn[i].currentbyte <
 				    axel->conn[i].lastbyte &&
 				    axel->size != LLONG_MAX) {
 					axel_message(axel,

--- a/src/http.c
+++ b/src/http.c
@@ -113,8 +113,6 @@ http_connect(http_t *conn, int proto, char *proxy, char *host, int port,
 
 	if (proxy != NULL) {
 		if (*proxy != 0) {
-			snprintf(conn->host, sizeof(conn->host),
-				 "%s:%i", host, port);
 			if (!conn_set(tconn, proxy)) {
 				fprintf(stderr,
 					_("Invalid proxy string: %s\n"), proxy);

--- a/src/http.c
+++ b/src/http.c
@@ -197,7 +197,7 @@ http_get(http_t *conn, char *lurl)
 	if (conn->firstbyte >= 0) {
 		if (conn->lastbyte)
 			http_addheader(conn, "Range: bytes=%lld-%lld",
-				       conn->firstbyte, conn->lastbyte);
+				       conn->firstbyte, conn->lastbyte - 1);
 		else
 			http_addheader(conn, "Range: bytes=%lld-",
 				       conn->firstbyte);


### PR DESCRIPTION
Fix http range error mentioned in #322 

Fix wrong currentbyte and lastbyte comparsion. The download should be considered finished when currentbyte = lastbyte since lastbyte is greater by 1 than the actual index of the last byte in the block.

Sometimes I get "Connection x unexpectedly closed" message during normal download. Maybe it's related to the comparsion problem.