### PR TITLE
axel: fix delay_time calculation

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -129,8 +129,8 @@ typedef struct {
 	char filename[MAX_STRING];
 	double start_time;
 	int next_state, finish_time;
-	size_t bytes_done, start_byte, size;
-	int bytes_per_second;
+	off_t bytes_done, start_byte, size;
+	long long int bytes_per_second;
 	struct timespec delay_time;
 	int outfd;
 	int ready;

--- a/src/conf.c
+++ b/src/conf.c
@@ -161,10 +161,21 @@ conf_loadfile(conf_t *conf, const char *file)
 			KEY(search_amount)
 			KEY(search_top)
 		else
-			goto other_keys;
+			goto long_num_keys;
 
 		/* Save numeric option */
 		*((int *)dst) = atoi(value);
+		continue;
+
+		/* Long numeric options */
+ long_num_keys:
+		MATCH
+			KEY(max_speed)
+		else
+			goto other_keys;
+
+		/* Save numeric option */
+		*((unsigned long long *)dst) = strtoull(value, NULL, 10);
 		continue;
 
  other_keys:

--- a/src/conf.h
+++ b/src/conf.h
@@ -53,7 +53,7 @@ typedef struct {
 	int reconnect_delay;
 	int max_redirect;
 	int buffer_size;
-	int max_speed;
+	unsigned long long max_speed;
 	int verbose;
 	int alternate_output;
 	int insecure;

--- a/src/conn.c
+++ b/src/conn.c
@@ -302,7 +302,7 @@ conn_setup(conn_t *conn)
 		conn->tcp = &conn->ftp->data_tcp;
 
 		if (conn->currentbyte) {
-			ftp_command(conn->ftp, "REST %lld", conn->currentbyte);
+			ftp_command(conn->ftp, "REST %jd", conn->currentbyte);
 			if (ftp_wait(conn->ftp) / 100 != 3 &&
 			    conn->ftp->status / 100 != 2)
 				return 0;

--- a/src/conn.h
+++ b/src/conn.h
@@ -85,9 +85,9 @@ typedef struct {
 
 	ftp_t ftp[1];
 	http_t http[1];
-	long long int size;	/* File size, not 'connection size'.. */
-	long long int currentbyte;
-	long long int lastbyte;
+	off_t size; /* File size, not 'connection size'.. */
+	off_t currentbyte;
+	off_t lastbyte;
 	tcp_t *tcp;
 	bool enabled;
 	bool supported;

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -111,17 +111,17 @@ ftp_cwd(ftp_t *conn, char *cwd)
 }
 
 /* Get file size. Should work with all reasonable servers now */
-long long int
+off_t
 ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout)
 {
-	long long int i, j, size = MAX_STRING;
+	off_t i, j, size = MAX_STRING;
 	char *reply, *s, fn[MAX_STRING];
 
 	/* Try the SIZE command first, if possible */
 	if (!strchr(file, '*') && !strchr(file, '?')) {
 		ftp_command(conn, "SIZE %s", file);
 		if (ftp_wait(conn) / 100 == 2) {
-			sscanf(conn->message, "%*i %lld", &i);
+			sscanf(conn->message, "%*i %jd", &i);
 			return i;
 		} else if (conn->status / 10 != 50) {
 			fprintf(stderr, _("File not found.\n"));
@@ -213,10 +213,10 @@ ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout)
 	   possible wildcards. */
 	else {
 		s = strstr(reply, "\n-");
-		i = sscanf(s, "%*s %*i %*s %*s %lld %*s %*i %*s %100s", &size,
+		i = sscanf(s, "%*s %*i %*s %*s %jd %*s %*i %*s %100s", &size,
 			   fn);
 		if (i < 2) {
-			i = sscanf(s, "%*s %*i %lld %*i %*s %*i %*i %100s",
+			i = sscanf(s, "%*s %*i %jd %*i %*s %*i %*i %100s",
 				   &size, fn);
 			if (i < 2) {
 				return -2;

--- a/src/ftp.h
+++ b/src/ftp.h
@@ -65,6 +65,6 @@ __attribute__((format(printf, 2, 3)))
 int ftp_command(ftp_t *conn, const char *format, ...);
 int ftp_cwd(ftp_t *conn, char *cwd);
 int ftp_data(ftp_t *conn, unsigned io_timeout);
-long long int ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout);
+off_t ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout);
 
 #endif				/* AXEL_FTP_H */

--- a/src/http.c
+++ b/src/http.c
@@ -189,10 +189,10 @@ http_get(http_t *conn, char *lurl)
 	http_addheader(conn, "Accept: */*");
 	http_addheader(conn, "Accept-Encoding: identity");
 	if (conn->lastbyte && conn->firstbyte >= 0) {
-		http_addheader(conn, "Range: bytes=%lld-%lld",
+		http_addheader(conn, "Range: bytes=%jd-%jd",
 			       conn->firstbyte, conn->lastbyte - 1);
 	} else if (conn->firstbyte >= 0) {
-		http_addheader(conn, "Range: bytes=%lld-",
+		http_addheader(conn, "Range: bytes=%jd-",
 			       conn->firstbyte);
 	}
 }
@@ -313,20 +313,20 @@ http_header(const http_t *conn, const char *header)
 	return NULL;
 }
 
-long long int
+off_t
 http_size(http_t *conn)
 {
 	const char *i;
-	long long int j;
+	off_t j;
 
 	if ((i = http_header(conn, "Content-Length:")) == NULL)
 		return -2;
 
-	sscanf(i, "%lld", &j);
+	sscanf(i, "%jd", &j);
 	return j;
 }
 
-long long int
+off_t
 http_size_from_range(http_t *conn)
 {
 	const char *i;
@@ -337,7 +337,7 @@ http_size_from_range(http_t *conn)
 	if (!i++)
 		return -2;
 
-	long long int j = strtoll(i, NULL, 10);
+	off_t j = strtoll(i, NULL, 10);
 	if (!j && *i != '0')
 		return -3;
 

--- a/src/http.h
+++ b/src/http.h
@@ -51,8 +51,8 @@ typedef struct {
 	int proto;		/* FTP through HTTP proxies */
 	int proxy;
 	char proxy_auth[MAX_STRING];
-	long long int firstbyte;
-	long long int lastbyte;
+	off_t firstbyte;
+	off_t lastbyte;
 	int status;
 	tcp_t tcp;
 	char *local_if;
@@ -69,8 +69,8 @@ void http_addheader(http_t *conn, const char *format, ...);
 int http_exec(http_t *conn);
 const char *http_header(const http_t *conn, const char *header);
 void http_filename(const http_t *conn, char *filename);
-long long int http_size(http_t *conn);
-long long int http_size_from_range(http_t *conn);
+off_t http_size(http_t *conn);
+off_t http_size_from_range(http_t *conn);
 void http_encode(char *s, size_t len);
 void http_decode(char *s);
 

--- a/src/search.c
+++ b/src/search.c
@@ -128,7 +128,7 @@ search_makelist(search_t *results, char *orig_url)
 		 /* Sorting:         */ "o=n&"
 		 /* Filename:        */ "q=%s&"
 		 /* Num. of results: */ "m=%i&"
-		 /* Size (min/max):  */ "s1=%lld&s2=%lld",
+		 /* Size (min/max):  */ "s1=%jd&s2=%jd",
 		 conn->file, results->conf->search_amount,
 		 conn->size, conn->size);
 

--- a/src/search.h
+++ b/src/search.h
@@ -42,7 +42,7 @@
 typedef struct {
 	char url[MAX_STRING];
 	double speed_start_time;
-	int speed, size;
+	off_t speed, size;
 	pthread_t speed_thread[1];
 	conf_t *conf;
 } search_t;


### PR DESCRIPTION
In the original code delay_time is cleared when the speed is within spec. It should be cleared only when it's too small for another substraction.
