### PR TITLE
Implements #348, percentage output (for piping)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -154,6 +154,7 @@ conf_loadfile(conf_t *conf, const char *file)
 			KEY(max_speed)
 			KEY(verbose)
 			KEY(alternate_output)
+			KEY(percentage)
 			KEY(insecure)
 			KEY(no_clobber)
 			KEY(search_timeout)
@@ -263,9 +264,9 @@ conf_init(conf_t *conf)
 
 	conf->interfaces->next = conf->interfaces;
 
-    /* Detect if stdout is a tty, set the default indicator to alternate.
-       Otherwise, keep it to original.*/
-    conf->alternate_output = isatty(STDOUT_FILENO);
+	/* Detect if stdout is a tty, set the default indicator to alternate.
+	   Otherwise, keep it to original.*/
+	conf->alternate_output = isatty(STDOUT_FILENO);
 
 	if ((s2 = getenv("http_proxy")) || (s2 = getenv("HTTP_PROXY")))
 		strlcpy(conf->http_proxy, s2, sizeof(conf->http_proxy));

--- a/src/conf.h
+++ b/src/conf.h
@@ -58,6 +58,7 @@ typedef struct {
 	int alternate_output;
 	int insecure;
 	int no_clobber;
+	int percentage;
 
 	if_t *interfaces;
 


### PR DESCRIPTION
Caveat: I haven't written C in a couple of decades, so this is my best attempt. I tried to follow your coding idioms. I've verified that it matches what I suggested in the ticket, and that zenity accepts it:

```
./axel -p https://github.com/axel-download-accelerator/axel/archive/refs/tags/v2.17.10.tar.gz | zenity --progress --auto-close
```

I would have liked to have gotten rid of the set-up and tear-down messages; zenity ignores them, but other commands may not, but `print_messages()` confounded me.