### PR TITLE
Add wolfSSL support with fallback to openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,8 +184,17 @@ AS_IF([test "x$with_ssl" != xno], [
         PKG_CONFIG_PATH="$with_ssl/lib/pkgconfig$PATH_SEPARATOR$PKG_CONFIG_PATH"
         export PKG_CONFIG_PATH
     ])
-    PKG_CHECK_MODULES([SSL], [openssl])
+    # try to use wolfSSL first and then callback to openssl
+    PKG_CHECK_MODULES([WOLFSSL], [wolfssl],
+        [AC_DEFINE([HAVE_WOLFSSL], [1], [Using wolfSSL])
+            SSL_CFLAGS="$WOLFSSL_CFLAGS $WOLFSSL_CFLAGS/wolfssl"
+            SSL_LIBS="$WOLFSSL_LIBS"
+            ],
+            [PKG_CHECK_MODULES([SSL], [openssl])]
+        )
+
     AC_DEFINE([HAVE_SSL], [1], [SSL])
+
     save_LIBS="$LIBS"
     LIBS="$LIBS $SSL_LIBS"
     AC_REPLACE_FUNCS([ \

--- a/lib/ASN1_STRING_get0_data.c
+++ b/lib/ASN1_STRING_get0_data.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "config.h"
+
+#ifdef HAVE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include "compat-ssl.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ axel_SOURCES += \
 	src/ssl_verify.c
 endif
 
-AM_CFLAGS = $(PTHREAD_CFLAGS) $(WARN_CFLAGS) \
+AM_CFLAGS = $(PTHREAD_CFLAGS) $(WARN_CFLAGS) $(SSL_CFLAGS)\
 	-Wno-declaration-after-statement \
 	-Wno-error=cast-align \
 	-Wno-error=inline

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -40,6 +40,13 @@
 /* SSL interface */
 
 #include "config.h"
+#ifdef HAVE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
+#include <openssl/ssl.h>
+
 #include <openssl/err.h>
 #include "axel.h"
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -41,6 +41,13 @@
 #if !defined(AXEL_SSL_H) && defined(HAVE_SSL)
 #define AXEL_SSL_H
 
+#include <config.h>
+
+#ifdef HAVE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/ssl.h>
 
 void ssl_init(conf_t *conf);

--- a/src/ssl_verify.c
+++ b/src/ssl_verify.c
@@ -27,6 +27,12 @@
  */
 
 #include "config.h"
+
+#ifdef HAVE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include "axel.h"
@@ -49,13 +55,13 @@ int
 matches_cn(const char *hostname, const X509 *cert)
 {
 	/* Find CN field in the Subject field */
-	int loc = X509_NAME_get_index_by_NID(X509_get_subject_name(cert),
+	int loc = X509_NAME_get_index_by_NID(X509_get_subject_name((X509*)cert),
 					     NID_commonName, -1);
 	if (loc < 0)
 		return 1;
 
 	X509_NAME_ENTRY *entry;
-	entry = X509_NAME_get_entry(X509_get_subject_name(cert), loc);
+	entry = X509_NAME_get_entry(X509_get_subject_name((X509*)cert), loc);
 	if (!entry)
 		return 1;
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -43,7 +43,14 @@
 #ifndef AXEL_TCP_H
 #define AXEL_TCP_H
 
+#include <config.h>
+
 #ifdef HAVE_SSL
+#ifdef HAVE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/ssl.h>
 #endif
 


### PR DESCRIPTION
Casting `const` away for `X509_get_subject_name` is not ideal but
required for difference in API constness

Signed-off-by: Elms <jeff@wolfssl.com>