### PR TITLE
Fix new compiler warning/errors on macOS LLVM/Clang 14.0.3

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -234,7 +234,7 @@ axel_new(conf_t *conf, int count, const search_t *res)
 		if (axel->size != LLONG_MAX) {
 			char hsize[32];
 			axel_size_human(hsize, sizeof(hsize), axel->size);
-			axel_message(axel, _("File size: %s (%jd bytes)"),
+			axel_message(axel, _("File size: %s (%lld bytes)"),
 				     hsize, axel->size);
 		} else {
 			axel_message(axel, _("File size: unavailable"));
@@ -343,7 +343,7 @@ axel_open(axel_t *axel)
 		}
 
 		axel_message(axel,
-			     _("State file found: %jd bytes downloaded, %jd to go."),
+			     _("State file found: %lld bytes downloaded, %lld to go."),
 			     axel->bytes_done, axel->size - axel->bytes_done);
 
 		close(fd);
@@ -917,7 +917,7 @@ axel_divide(axel_t *axel)
 	axel->conn[axel->conf->num_connections - 1].lastbyte += tail;
 #ifndef NDEBUG
 	for (int i = 0; i < axel->conf->num_connections; i++) {
-		printf(_("Downloading %jd-%jd using conn. %i\n"),
+		printf(_("Downloading %lld-%lld using conn. %i\n"),
 		       axel->conn[i].currentbyte,
 		       axel->conn[i].lastbyte, i);
 	}

--- a/src/conn.c
+++ b/src/conn.c
@@ -302,7 +302,7 @@ conn_setup(conn_t *conn)
 		conn->tcp = &conn->ftp->data_tcp;
 
 		if (conn->currentbyte) {
-			ftp_command(conn->ftp, "REST %jd", conn->currentbyte);
+			ftp_command(conn->ftp, "REST %lld", conn->currentbyte);
 			if (ftp_wait(conn->ftp) / 100 != 3 &&
 			    conn->ftp->status / 100 != 2)
 				return 0;

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -123,7 +123,7 @@ ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout)
 	if (!strchr(file, '*') && !strchr(file, '?')) {
 		ftp_command(conn, "SIZE %s", file);
 		if (ftp_wait(conn) / 100 == 2) {
-			sscanf(conn->message, "%*i %jd", &i);
+			sscanf(conn->message, "%*i %lld", &i);
 			return i;
 		} else if (conn->status / 10 != 50) {
 			fprintf(stderr, _("File not found.\n"));
@@ -215,10 +215,10 @@ ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout)
 	   possible wildcards. */
 	else {
 		s = strstr(reply, "\n-");
-		i = sscanf(s, "%*s %*i %*s %*s %jd %*s %*i %*s %100s", &size,
+		i = sscanf(s, "%*s %*i %*s %*s %lld %*s %*i %*s %100s", &size,
 			   fn);
 		if (i < 2) {
-			i = sscanf(s, "%*s %*i %jd %*i %*s %*i %*i %100s",
+			i = sscanf(s, "%*s %*i %lld %*i %*s %*i %*i %100s",
 				   &size, fn);
 			if (i < 2) {
 				return -2;

--- a/src/http.c
+++ b/src/http.c
@@ -191,10 +191,10 @@ http_get(http_t *conn, char *lurl)
 	http_addheader(conn, "Accept: */*");
 	http_addheader(conn, "Accept-Encoding: identity");
 	if (conn->lastbyte && conn->firstbyte >= 0) {
-		http_addheader(conn, "Range: bytes=%jd-%jd",
+		http_addheader(conn, "Range: bytes=%lld-%lld",
 			       conn->firstbyte, conn->lastbyte - 1);
 	} else if (conn->firstbyte >= 0) {
-		http_addheader(conn, "Range: bytes=%jd-",
+		http_addheader(conn, "Range: bytes=%lld-",
 			       conn->firstbyte);
 	}
 }
@@ -324,7 +324,7 @@ http_size(http_t *conn)
 	if ((i = http_header(conn, "Content-Length:")) == NULL)
 		return -2;
 
-	sscanf(i, "%jd", &j);
+	sscanf(i, "%lld", &j);
 	return j;
 }
 

--- a/src/random.c
+++ b/src/random.c
@@ -2,16 +2,16 @@
 #include <unistd.h>
 #include "config.h"
 #include "axel.h"
+#include <stdatomic.h>
 
-ssize_t
-axel_rand64(uint64_t *out)
+ssize_t axel_rand64(uint64_t *out)
 {
-	static int fd = -1;
-	if (fd == -1) {
-		int tmp = open("/dev/random", O_RDONLY);
-		int expect = -1;
-		if (!atomic_compare_exchange_strong(&fd, &expect, tmp))
-			close(tmp);
-	}
-	return read(fd, out, sizeof(*out));
+    static _Atomic int fd = -1;
+    if (atomic_load(&fd) == -1) {
+        int tmp = open("/dev/random", O_RDONLY);
+        int expect = -1;
+        if (!atomic_compare_exchange_strong(&fd, &expect, tmp))
+            close(tmp);
+    }
+    return read(atomic_load(&fd), out, sizeof(*out));
 }

--- a/src/search.c
+++ b/src/search.c
@@ -130,7 +130,7 @@ search_makelist(search_t *results, char *orig_url)
 		 /* Sorting:         */ "o=n&"
 		 /* Filename:        */ "q=%s&"
 		 /* Num. of results: */ "m=%i&"
-		 /* Size (min/max):  */ "s1=%jd&s2=%jd",
+		 /* Size (min/max):  */ "s1=%lld&s2=%lld",
 		 conn->file, results->conf->search_amount,
 		 conn->size, conn->size);
 

--- a/src/text.c
+++ b/src/text.c
@@ -309,7 +309,7 @@ main(int argc, char *argv[])
 			j = min(j, conf->search_top);
 			printf("%-60s %15s\n", "URL", _("Speed"));
 			for (i = 0; i < j; i++)
-				printf("%-70.70s %5jd\n", search[i].url,
+				printf("%-70.70s %5lld\n", search[i].url,
 				       search[i].speed);
 			printf("\n");
 		}


### PR DESCRIPTION
Switch printf formatters from `%jd` to`%lld` for `long long`-typed variables.
Update axel_rand64 function for C11, now uses proper _Atomic specifiers.