### PR TITLE
Increase max url length from 1024 to 2048

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -89,7 +89,7 @@
 #endif
 
 /* Compiled-in settings */
-#define MAX_STRING		((size_t)1024)
+#define MAX_STRING		((size_t)2048)
 #define MAX_ADD_HEADERS	10
 #define MAX_REDIRECT		20
 #define DEFAULT_IO_TIMEOUT	120


### PR DESCRIPTION
Presigned URLs from AWS S3 are sometimes longer than 1024 chars.