### PR TITLE
Fix potential memory leak in abuf_setup

### DIFF
--- a/src/abuf.c
+++ b/src/abuf.c
@@ -53,6 +53,10 @@
 int
 abuf_setup(abuf_t *abuf, size_t len)
 {
+	if (len == 0) {
+		free(abuf->p);
+		return 0;
+	}
 	char *p = realloc(abuf->p, len);
 	if (!p && len)
 		return -ENOMEM;


### PR DESCRIPTION
Closes #414 

Dirty solution, I am not sure if there might be any unintended side effects, are there any calls with `len = 0`, where we don't want to `free`?