### PR TITLE
fix: patch random.c

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -6,7 +6,7 @@
 ssize_t
 axel_rand64(uint64_t *out)
 {
-	static int fd = -1;
+	static _Atomic int fd = -1;
 	if (fd == -1) {
 		int tmp = open("/dev/random", O_RDONLY);
 		int expect = -1;


### PR DESCRIPTION
```
  src/random.c:13:8: error: address argument to atomic operation must be a pointer to _Atomic type ('int *' invalid)
                  if (!atomic_compare_exchange_strong(&fd, &expect, tmp))
                       ^                              ~~~
  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/include/stdatomic.h:139:67: note: expanded from macro 'atomic_compare_exchange_strong'
  #define atomic_compare_exchange_strong(object, expected, desired) __c11_atomic_compare_exchange_strong(object, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
                                                                    ^                                    ~~~~~~
  1 error generated.
```

Thanks to @Biswa96!

relates to https://github.com/Homebrew/homebrew-core/pull/161270