### PR TITLE
http: Fix filename parsing from content-disposition

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -359,7 +359,7 @@ http_filename(const http_t *conn, char *filename)
 {
 	const char *h;
 	if ((h = http_header(conn, "Content-Disposition:")) != NULL) {
-		sscanf(h, "%*s%*[ \t]filename%*[ \t=\"\'-]%254[^\n\"\']",
+		sscanf(h, "%*s%*[ \t]filename%*[ \t=\"\'-]%254[^;\n\"\']",
 		       filename);
 		/* Trim spaces at the end of string */
 		const char space[] = "\t ";


### PR DESCRIPTION
Fixes #429.

This not mostly ideal (RFC 6266 prefers `filename*` if present) yet may be considered good enough if we don't want to introdue UTF-8 decoding here.