### PR TITLE
Fixed possible overflow in conn.c

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -527,8 +527,8 @@ conn_info_status_get(char *msg, size_t size, conn_t *conn)
 	if (is_proto_http(conn->proto)) {
 		char *p = conn->http->headers->p;
 		/* Skip protocol and code */
-		while (*p++ != ' ');
-		while (*p++ != ' ');
+		while (*p++ != ' ' && *p != '\0');
+		while (*p++ != ' ' && *p != '\0');
 		size_t len = strcspn(p, "\r\n");
 		if (len) {
 			strlcpy(msg, p, min(len + 1, size));


### PR DESCRIPTION
while loop could cause a segfault when server gives an empty response