### PR TITLE
Increase URL length limit

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -89,7 +89,7 @@
 #endif
 
 /* Compiled-in settings */
-#define MAX_STRING		((size_t)1024)
+#define MAX_STRING		((size_t)8100)
 #define MAX_ADD_HEADERS	10
 #define MAX_REDIRECT		20
 #define DEFAULT_IO_TIMEOUT	120

--- a/src/conn.c
+++ b/src/conn.c
@@ -423,7 +423,7 @@ conn_info(conn_t *conn)
 		return conn_info_ftp(conn);
 	}
 
-	char s[1005];
+	char s[8005];
 	long long int i = 0;
 
 	struct urlseq *urlseq = urlseq_init(conn->conf->max_redirect);
@@ -448,7 +448,7 @@ conn_info(conn_t *conn)
 			break;
 		if ((t = http_header(conn->http, "location:")) == NULL)
 			return 0;
-		sscanf(t, "%1000s", s);
+		sscanf(t, "%8000s", s);
 		if (s[0] == '/') {
 			abuf_printf(conn->http->headers, "%s%s:%i%s",
 				    scheme_from_proto(conn->proto),


### PR DESCRIPTION
Current limit is too aggressive and truncates e.g. CloudFront signed URLs.

As per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-4.1-5):
> It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements. Note that this implies some structures and on-wire representations (for example, the request line in HTTP/1.1) will necessarily be larger in some cases.


Fixes #440, closes #407