### PR TITLE
Add support for dynamic url length to fix #185

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -126,6 +126,11 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	url_t *u;
 	char *s;
 	int i;
+	uint64_t delay;
+	char msg[80];
+	size_t url_buf_size;
+	char *temp_url;
+	int code;
 
 	if (!count || !res)
 		return NULL;
@@ -150,8 +155,7 @@ axel_new(conf_t *conf, int count, const search_t *res)
 					     _("Buffer resized for this speed."));
 			axel->conf->buffer_size = axel->conf->max_speed;
 		}
-		uint64_t delay =
-			UINT64_C(1073741824) * axel->conf->buffer_size *
+		delay = UINT64_C(1073741824) * axel->conf->buffer_size *
 			axel->conf->num_connections / axel->conf->max_speed;
 
 		axel->delay_time.tv_sec  = delay / 1073741824;
@@ -169,7 +173,16 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	axel->url = u;
 
 	for (i = 0; i < count; i++) {
-		strlcpy(u[i].text, res[i].url, sizeof(u[i].text));
+		size_t url_len = strlen(res[i].url) + 1;
+		u[i].text = malloc(url_len);
+		if (!u[i].text) {
+			for (int k = 0; k < i; k++)
+				free(u[k].text);
+			free(u);
+			axel->url = NULL;
+			goto nomem;
+		}
+		strlcpy(u[i].text, res[i].url, url_len);
 		u[i].next = &u[i + 1];
 	}
 	u[count - 1].next = u;
@@ -218,8 +231,7 @@ axel_new(conf_t *conf, int count, const search_t *res)
 		 * depends on the protocol used. */
 		status = conn_info(&axel->conn[0]);
 		if (!status) {
-			char msg[80];
-			int code = conn_info_status_get(msg, sizeof(msg), axel->conn);
+			code = conn_info_status_get(msg, sizeof(msg), axel->conn);
 			fprintf(stderr, _("ERROR %d: %s.\n"), code, msg);
 			axel->ready = -1;
 			return axel;
@@ -228,7 +240,17 @@ axel_new(conf_t *conf, int count, const search_t *res)
 				 * happen only once because the FTP protocol
 				 * can't redirect back to HTTP */
 
-	conn_url(axel->url->text, sizeof(axel->url->text) - 1, axel->conn);
+	url_buf_size = 4096;
+	temp_url = malloc(url_buf_size);
+	if (!temp_url) {
+		axel_message(axel, _("Out of memory\n"));
+		axel->ready = -1;
+		return axel;
+	}
+	conn_url(temp_url, url_buf_size - 1, axel->conn);
+	free(axel->url->text);
+	axel->url->text = temp_url;
+
 	axel->size = axel->conn[0].size;
 	if (axel->conf->verbose > 0) {
 		if (axel->size != LLONG_MAX) {
@@ -743,9 +765,23 @@ axel_close(axel_t *axel)
 			pthread_join(*axel->conn[i].setup_thread, NULL);
 		}
 		conn_disconnect(&axel->conn[i]);
+		if (axel->conn[i].dir) {
+			free(axel->conn[i].dir);
+		}
+		if (axel->conn[i].file) {
+			free(axel->conn[i].file);
+		}
 	}
 
-	free(axel->url);
+	if (axel->url) {
+		url_t *current = axel->url;
+		url_t *first = axel->url;
+		do {
+			free(current->text);
+			current = current->next;
+		} while (current != first);
+		free(axel->url);
+	}
 
 	/* Delete state file if necessary */
 	if (axel->ready == 1) {
@@ -863,6 +899,12 @@ axel_message(axel_t *axel, const char *format, ...)
 	m = calloc(1, sizeof(message_t));
 	if (!m)
 		goto nomem;
+
+	m->text = malloc(MAX_STRING);
+	if (!m->text) {
+		free(m);
+		goto nomem;
+	}
 
 	va_start(params, format);
 	vsnprintf(m->text, MAX_STRING, format, params);

--- a/src/axel.h
+++ b/src/axel.h
@@ -97,7 +97,7 @@
 
 typedef struct {
 	void *next;
-	char text[MAX_STRING];
+	char *text;
 } message_t;
 
 typedef message_t url_t;

--- a/src/conf.c
+++ b/src/conf.c
@@ -321,7 +321,19 @@ conf_init(conf_t *conf)
 void
 conf_free(conf_t *conf)
 {
-	free(conf->interfaces);
+	if (conf->interfaces) {
+		axel_if_t *iface = conf->interfaces->next;
+		while (iface != conf->interfaces) {
+			axel_if_t *next = iface->next;
+			if (iface->text)
+				free(iface->text);
+			free(iface);
+			iface = next;
+		}
+		if (conf->interfaces->text)
+			free(conf->interfaces->text);
+		free(conf->interfaces);
+	}
 }
 
 static
@@ -336,9 +348,13 @@ parse_interfaces(conf_t *conf, char *s)
 		axel_if_t *i;
 
 		i = iface->next;
+		if (iface->text)
+			free(iface->text);
 		free(iface);
 		iface = i;
 	}
+	if (conf->interfaces->text)
+		free(conf->interfaces->text);
 	free(conf->interfaces);
 
 	if (!*s) {
@@ -359,10 +375,15 @@ parse_interfaces(conf_t *conf, char *s)
 			s++;
 		for (s2 = s; *s2 != ' ' && *s2 != '\t' && *s2; s2++) ;
 		*s2 = 0;
+
+		iface->text = malloc(MAX_STRING);
+		if (!iface->text)
+			return 0;
+
 		if (*s < '0' || *s > '9')
-			get_if_ip(iface->text, sizeof(iface->text), s);
+			get_if_ip(iface->text, MAX_STRING, s);
 		else
-			strlcpy(iface->text, s, sizeof(iface->text));
+			strlcpy(iface->text, s, MAX_STRING);
 		s = s2 + 1;
 		if (*s) {
 			iface->next = malloc(sizeof(*iface));

--- a/src/conn.c
+++ b/src/conn.c
@@ -55,14 +55,24 @@
 int
 conn_set(conn_t *conn, const char *set_url)
 {
-	char url[MAX_STRING];
+	if (conn->dir) {
+		free(conn->dir);
+		conn->dir = NULL;
+	}
+	if (conn->file) {
+		free(conn->file);
+		conn->file = NULL;
+	}
+
 	char *i, *j;
+	char *url;
+	const char *url_without_proto;
 
 	/* protocol:// */
 	if ((i = strstr(set_url, "://")) == NULL) {
 		conn->proto = PROTO_DEFAULT;
 		conn->port = PROTO_DEFAULT_PORT;
-		strlcpy(url, set_url, sizeof(url));
+		url_without_proto = set_url;
 	} else {
 		int proto_len = i - set_url;
 		if (strncmp(set_url, "ftp", proto_len) == 0) {
@@ -88,15 +98,35 @@ conn_set(conn_t *conn, const char *set_url)
                        return 0;
                }
 #endif
-		strlcpy(url, i + 3, sizeof(url));
+		url_without_proto = i + 3;
 	}
+
+	url = malloc(strlen(url_without_proto) + 1);
+	if (!url) {
+		fprintf(stderr, "Out of memory\n");
+		return 0;
+	}
+	strlcpy(url, url_without_proto, strlen(url_without_proto) + 1);
 
 	/* Split */
 	if ((i = strchr(url, '/')) == NULL) {
-		strcpy(conn->dir, "/");
+		conn->dir = malloc(2);
+		if (!conn->dir) {
+			fprintf(stderr, "Out of memory\n");
+			free(url);
+			return 0;
+		}
+		strlcpy(conn->dir, "/", 2);
 	} else {
 		*i = 0;
-		snprintf(conn->dir, MAX_STRING, "/%s", i + 1);
+		size_t dir_len = strlen(i + 1) + 2; /* "/" + path + "\0" */
+		conn->dir = malloc(dir_len);
+		if (!conn->dir) {
+			fprintf(stderr, "Out of memory\n");
+			free(url);
+			return 0;
+		}
+		snprintf(conn->dir, dir_len, "/%s", i + 1);
 	}
 	j = strchr(conn->dir, '?');
 	if (j != NULL)
@@ -108,11 +138,49 @@ conn_set(conn_t *conn, const char *set_url)
 	if (j != NULL)
 		*j = '?';
 	if (i == NULL) {
-		strlcpy(conn->file, conn->dir, sizeof(conn->file));
-		strcpy(conn->dir, "/");
+		size_t dir_size = strlen(conn->dir) + 1;
+		conn->file = malloc(dir_size);
+		if (!conn->file) {
+			fprintf(stderr, "Out of memory\n");
+			free(conn->dir);
+			free(url);
+			return 0;
+		}
+		strlcpy(conn->file, conn->dir, dir_size);
+		free(conn->dir);
+		conn->dir = malloc(2);
+		if (!conn->dir) {
+			fprintf(stderr, "Out of memory\n");
+			free(conn->file);
+			conn->file = NULL;
+			free(url);
+			return 0;
+		}
+		strlcpy(conn->dir, "/", 2);
 	} else {
-		strlcpy(conn->file, i + 1, sizeof(conn->file));
-		strlcat(conn->dir, "/", sizeof(conn->dir));
+		size_t file_len = strlen(i + 1) + 1;
+		conn->file = malloc(file_len);
+		if (!conn->file) {
+			fprintf(stderr, "Out of memory\n");
+			free(conn->dir);
+			conn->dir = NULL;
+			free(url);
+			return 0;
+		}
+		strlcpy(conn->file, i + 1, file_len);
+		size_t new_dir_len = strlen(conn->dir) + 2;
+		char *new_dir = realloc(conn->dir, new_dir_len);
+		if (!new_dir) {
+			fprintf(stderr, "Out of memory\n");
+			free(conn->file);
+			conn->file = NULL;
+			free(conn->dir);
+			conn->dir = NULL;
+			free(url);
+			return 0;
+		}
+		conn->dir = new_dir;
+		strlcat(conn->dir, "/", new_dir_len);
 	}
 
 	/* Check for username in host field */
@@ -121,7 +189,9 @@ conn_set(conn_t *conn, const char *set_url)
 		strlcpy(conn->user, url, sizeof(conn->user));
 		i = strrchr(conn->user, '@');
 		*i = 0;
-		strlcpy(url, i + 1, sizeof(url));
+		/* Extract host from user@host - shift string in place */
+		char *host_start = strrchr(url, '@') + 1;
+		memmove(url, host_start, strlen(host_start) + 1);
 		*conn->pass = 0;
 	} else {
 		/* If not: Fill in defaults */
@@ -147,6 +217,11 @@ conn_set(conn_t *conn, const char *set_url)
 		if ((i = strrchr(conn->host, ']')) != NULL) {
 			*i++ = 0;
 		} else {
+			free(conn->dir);
+			conn->dir = NULL;
+			free(conn->file);
+			conn->file = NULL;
+			free(url);
 			return 0;
 		}
 	} else {
@@ -164,6 +239,7 @@ conn_set(conn_t *conn, const char *set_url)
 		i = conn->host;
 	}
 
+	free(url);
 	return conn->port > 0;
 }
 
@@ -226,6 +302,10 @@ conn_disconnect(conn_t *conn)
 		http_disconnect(conn->http);
 	conn->tcp = NULL;
 	conn->enabled = false;
+
+	/* NOTE: dir and file are NOT freed here because they may be needed
+	 * for reconnection or URL rebuilding. They are freed in conn_set()
+	 * when replaced, or during final cleanup in axel_close(). */
 }
 
 int
@@ -306,16 +386,25 @@ conn_setup(conn_t *conn)
 				return 0;
 		}
 	} else {
-		char s[MAX_STRING * 2];
 		int i;
+		size_t url_len = strlen(conn->dir) + strlen(conn->file) + 1;
+		char *s = malloc(url_len);
+		if (!s) {
+			fprintf(stderr, "Out of memory\n");
+			return 0;
+		}
 
-		snprintf(s, sizeof(s), "%s%s", conn->dir, conn->file);
+		snprintf(s, url_len, "%s%s", conn->dir, conn->file);
 		conn->http->firstbyte =
 			conn->supported ? conn->currentbyte : -1;
 		conn->http->lastbyte = conn->lastbyte;
 
-		abuf_setup(conn->http->request, 2048);
+		size_t request_size = url_len + strlen(conn->host) + 512;
+		if (request_size < 2048)
+			request_size = 2048;
+		abuf_setup(conn->http->request, request_size);
 		http_get(conn->http, s);
+		free(s);
 		for (i = 0; i < conn->conf->add_header_count; i++)
 			http_addheader(conn->http, "%s",
 				       conn->conf->add_header[i]);

--- a/src/conn.h
+++ b/src/conn.h
@@ -86,8 +86,8 @@ typedef struct {
 	int port;
 	int proxy;
 	char host[MAX_STRING];
-	char dir[MAX_STRING];
-	char file[MAX_STRING];
+	char *dir;
+	char *file;
 	char user[MAX_STRING];
 	char pass[MAX_STRING];
 	char output_filename[MAX_STRING];

--- a/src/http.c
+++ b/src/http.c
@@ -109,13 +109,27 @@ http_connect(http_t *conn, int proto, char *proxy, char *host, int port,
 	const char *puser = NULL, *ppass = "";
 	conn_t tconn[1];
 
-	strlcpy(conn->host, host, sizeof(conn->host));
+	if (conn->host) {
+		free(conn->host);
+	}
+
+	size_t host_len = strlen(host) + 1;
+	conn->host = malloc(host_len);
+	if (!conn->host) {
+		fprintf(stderr, "Out of memory\n");
+		return 0;
+	}
+
+	strlcpy(conn->host, host, host_len);
 	conn->port = port;
 	conn->proto = proto;
 
 	if (proxy && *proxy) {
+		memset(tconn, 0, sizeof(conn_t));
 		if (!conn_set(tconn, proxy)) {
 			fprintf(stderr, _("Invalid proxy string: %s\n"), proxy);
+			free(conn->host);
+			conn->host = NULL;
 			return 0;
 		}
 		host = tconn->host;
@@ -127,8 +141,20 @@ http_connect(http_t *conn, int proto, char *proxy, char *host, int port,
 	}
 
 	if (tcp_connect(&conn->tcp, host, port, PROTO_IS_SECURE(proto),
-			conn->local_if, io_timeout) == -1)
+			conn->local_if, io_timeout) == -1) {
+		if (proxy && *proxy) {
+			free(tconn->dir);
+			free(tconn->file);
+		}
+		free(conn->host);
+		conn->host = NULL;
 		return 0;
+	}
+
+	if (proxy && *proxy) {
+		free(tconn->dir);
+		free(tconn->file);
+	}
 
 	if (*user == 0) {
 		*conn->auth = 0;
@@ -148,6 +174,10 @@ http_connect(http_t *conn, int proto, char *proxy, char *host, int port,
 void
 http_disconnect(http_t *conn)
 {
+	if (conn->host) {
+		free(conn->host);
+		conn->host = NULL;
+	}
 	tcp_close(&conn->tcp);
 }
 
@@ -202,17 +232,36 @@ http_get(http_t *conn, char *lurl)
 void
 http_addheader(http_t *conn, const char *format, ...)
 {
-	char s[MAX_STRING];
 	va_list params;
+	va_list params_copy;
+	int needed;
+	char *s;
 
 	va_start(params, format);
-	vsnprintf(s, sizeof(s) - 3, format, params);
-	strlcat(s, "\r\n", sizeof(s));
+	va_copy(params_copy, params);
+	needed = vsnprintf(NULL, 0, format, params);
 	va_end(params);
+
+	if (needed < 0) {
+		va_end(params_copy);
+		return;
+	}
+
+	s = malloc(needed + 3);
+	if (!s) {
+		va_end(params_copy);
+		return;
+	}
+
+	vsnprintf(s, needed + 1, format, params_copy);
+	strcat(s, "\r\n");
+	va_end(params_copy);
 
 	if (abuf_strcat(conn->request, s) < 0) {
 		fprintf(stderr, "Out of memory\n");
 	}
+
+	free(s);
 }
 
 int

--- a/src/http.h
+++ b/src/http.h
@@ -46,7 +46,7 @@
 #define AXEL_HTTP_H
 
 typedef struct {
-	char host[MAX_STRING];
+	char *host;
 	char auth[MAX_STRING];
 	abuf_t request[1], headers[1];
 	int port;

--- a/src/search.c
+++ b/src/search.c
@@ -109,8 +109,17 @@ search_makelist(search_t *results, char *orig_url)
 	if (!conn_set(conn, orig_url) || !conn_init(conn) || !conn_info(conn))
 		return -1;
 
-	size_t orig_len = strlcpy(results[0].url, orig_url,
-				  sizeof(results[0].url));
+	size_t orig_len = strlen(orig_url) + 1;
+	results[0].url = malloc(orig_len);
+	if (!results[0].url) {
+		fprintf(stderr, "Out of memory\n");
+		if (conn->dir)
+			free(conn->dir);
+		if (conn->file)
+			free(conn->file);
+		return -1;
+	}
+	strlcpy(results[0].url, orig_url, orig_len);
 	results[0].speed = 1 + 1000 * (axel_gettime() - t);
 	results[0].size = conn->size;
 	int nresults = 1;
@@ -135,6 +144,10 @@ search_makelist(search_t *results, char *orig_url)
 		 conn->size, conn->size);
 
 	conn_disconnect(conn);
+	if (conn->dir)
+		free(conn->dir);
+	if (conn->file)
+		free(conn->file);
 	memset(conn, 0, sizeof(conn_t));
 	conn->conf = results->conf;
 
@@ -191,13 +204,23 @@ search_makelist(search_t *results, char *orig_url)
 		if (!strncmp(url, orig_url, orig_len))
 			continue;
 
-		strlcpy(results[nresults].url, url, sizeof(results[0].url));
+		size_t url_len = strlen(url) + 1;
+		results[nresults].url = malloc(url_len);
+		if (!results[nresults].url) {
+			fprintf(stderr, "Out of memory\n");
+			break;
+		}
+		strlcpy(results[nresults].url, url, url_len);
 		results[nresults].size = results[0].size;
 		results[nresults].conf = results->conf;
 		++nresults;
 	}
 
 done:
+	if (conn->dir)
+		free(conn->dir);
+	if (conn->file)
+		free(conn->file);
 	free(s);
 	return nresults;
 }
@@ -299,6 +322,10 @@ search_speedtest(void *r)
 		results->speed = SPEED_FAILED;
 
 	conn_disconnect(conn);
+	if (conn->dir)
+		free(conn->dir);
+	if (conn->file)
+		free(conn->file);
 
 	return NULL;
 }

--- a/src/search.h
+++ b/src/search.h
@@ -42,7 +42,7 @@
 #define AXEL_SEARCH_H
 
 typedef struct {
-	char url[MAX_STRING];
+	char *url;
 	double speed_start_time;
 	off_t speed, size;
 	pthread_t speed_thread[1];

--- a/src/text.c
+++ b/src/text.c
@@ -272,12 +272,6 @@ main(int argc, char *argv[])
 		}
 	} else {
 		s = argv[optind];
-		if (strlen(s) > MAX_STRING) {
-			fprintf(stderr,
-				_("Can't handle URLs of length over %zu\n"),
-				MAX_STRING);
-			goto free_conf;
-		}
 	}
 
 	if (conf->progress_style != AXEL_PROGRESS_STYLE_PERCENTAGE)
@@ -294,6 +288,7 @@ main(int argc, char *argv[])
 		int i = search_makelist(search, s);
 		if (i < 0) {
 			fprintf(stderr, _("File not found\n"));
+			free(search);
 			goto free_conf;
 		}
 		if (conf->verbose)
@@ -301,9 +296,13 @@ main(int argc, char *argv[])
 		j = search_getspeeds(search, i);
 		if (j < 0) {
 			fprintf(stderr, _("Speed testing failed\n"));
+			for (int k = 0; k < i; k++)
+				free(search[k].url);
+			free(search);
 			return 1;
 		}
 
+		int search_count = i;
 		search_sortlist(search, i);
 		if (conf->verbose) {
 			printf(_("%i usable servers found, will use these URLs:\n"),
@@ -316,6 +315,8 @@ main(int argc, char *argv[])
 			printf("\n");
 		}
 		axel = axel_new(conf, j, search);
+		for (int k = 0; k < search_count; k++)
+			free(search[k].url);
 		free(search);
 		if (!axel || axel->ready == -1) {
 			print_messages(axel);
@@ -327,11 +328,20 @@ main(int argc, char *argv[])
 			goto free_conf;
 
 		for (int i = 0; i < argc - optind; i++) {
-			strlcpy(search[i].url, argv[optind + i],
-				sizeof(search[i].url));
+			size_t url_len = strlen(argv[optind + i]) + 1;
+			search[i].url = malloc(url_len);
+			if (!search[i].url) {
+				for (int k = 0; k < i; k++)
+					free(search[k].url);
+				free(search);
+				goto free_conf;
+			}
+			strlcpy(search[i].url, argv[optind + i], url_len);
 			// FIXME check url here
 		}
 		axel = axel_new(conf, argc - optind, search);
+		for (int i = 0; i < argc - optind; i++)
+			free(search[i].url);
 		free(search);
 		if (!axel || axel->ready == -1) {
 			print_messages(axel);
@@ -768,6 +778,7 @@ print_messages(axel_t *axel)
 	while ((m = axel->message)) {
 		printf("%s\n", m->text);
 		axel->message = m->next;
+		free(m->text);
 		free(m);
 	}
 }


### PR DESCRIPTION
The purpose of this pr is to remove the dependency on MAX_STRING for all operation related to the url length by moving all related variables to become pointers, and taking care of freeing the memory where needed.

I'd love some notes if any before I clean things up, or if you have another approach to this that's fundamentally different so that I don't waste my time doing the rest of the work. Thank you

Tasks (consider done when all checked)
- [x] Move the url variables to be dynamic
- [x] Test a short https urls
- [x] Test a long https url (tested with a signed aws s3 url)
- [ ] Test an insecure http url
- [ ] Test an ftp request
- [ ] Test a long filename in an ftp request
- [ ] Find a different solution for url rewrite malloc
- [ ] Clean up some code
- [ ] Update changelog