### PR TITLE
Fix quoted semicolon parsing in Content-Disposition filename

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,8 @@ axel_SOURCES = \
 	src/hash.h \
 	src/http.c \
 	src/http.h \
+	src/http_params.c \
+	src/http_params.h \
 	src/netrc.c \
 	src/netrc.h \
 	src/random.c \

--- a/src/http.c
+++ b/src/http.c
@@ -49,6 +49,7 @@
 
 #include "config.h"
 #include "axel.h"
+#include "http_params.h"
 
 #define HDR_CHUNK 512
 
@@ -359,26 +360,32 @@ void
 http_filename(const http_t *conn, char *filename)
 {
 	const char *h;
-	if ((h = http_header(conn, "Content-Disposition:")) != NULL) {
-		sscanf(h, "%*s%*[ \t]filename%*[ \t=\"\'-]%254[^;\n\"\']",
-		       filename);
-		/* Trim spaces at the end of string */
-		const char space[] = "\t ";
-		for (char *n, *p = filename; (p = strpbrk(p, space)); p = n) {
-			n = p + strspn(p, space);
-			if (!*n) {
-				*p = 0;
-				break;
-			}
-		}
+	struct header_params params[] = {
+		{ "filename", filename, MAX_STRING },
+	};
 
-		/* Replace common invalid characters in filename
-		   https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words */
-		const char invalid[] = "/\\?%*:|<>";
-		const char replacement = '_';
-		for (char *i = filename; (i = strpbrk(i, invalid)); i++) {
-			*i = replacement;
+	if ((h = http_header(conn, "Content-Disposition:")) == NULL)
+		return;
+
+	http_header_params(h, NULL, 0, params,
+			   sizeof(params) / sizeof(params[0]));
+
+	/* Trim spaces at the end of string */
+	const char space[] = "\t ";
+	for (char *n, *p = filename; (p = strpbrk(p, space)); p = n) {
+		n = p + strspn(p, space);
+		if (!*n) {
+			*p = 0;
+			break;
 		}
+	}
+
+	/* Replace common invalid characters in filename
+	   https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words */
+	const char invalid[] = "/\\?%*:|<>";
+	const char replacement = '_';
+	for (char *i = filename; (i = strpbrk(i, invalid)); i++) {
+		*i = replacement;
 	}
 }
 

--- a/src/http_params.c
+++ b/src/http_params.c
@@ -1,0 +1,159 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2001-2007 Wilmer van der Gaast
+  Copyright 2008      Y Giridhar Appaji Nag
+  Copyright 2008-2009 Philipp Hagemeister
+  Copyright 2015      Joao Eriberto Mota Filho
+  Copyright 2016      Ivan Gimenez
+  Copyright 2016      Phillip Berndt
+  Copyright 2016      Sjjad Hashemian
+  Copyright 2016      Stephen Thirlwall
+  Copyright 2017      Antonio Quartulli
+  Copyright 2017      David Polverari
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2018-2019 Shankar
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/* HTTP header parameter parsing */
+
+#include "config.h"
+#include "http_params.h"
+
+#include <string.h>
+#include <strings.h>
+
+/*
+ * Consume one parameter value, starting at *pp (just past '=').  A value may
+ * be quoted ('"' or '\'') and quoted values may use backslash escapes.  The
+ * decoded (unquoted) value is copied into dest, NUL-terminated and limited to
+ * length bytes, when dest is non-NULL; otherwise it is only skipped.  On
+ * return *pp points just past the value.
+ */
+static void
+http_param_value(const char **pp, const char *end, char *dest, size_t length)
+{
+	const char *p = *pp;
+	const char quote = (*p == '"' || *p == '\'') ? *p++ : 0;
+	char *out = dest;
+	char *out_end = dest ? dest + length - 1 : NULL;
+
+	while (p < end) {
+		if (quote) {
+			if (*p == quote) {	/* closing quote */
+				p++;
+				break;
+			}
+			if (*p == '\\' && p + 1 < end) {	/* escaped char */
+				if (out && out < out_end)
+					*out++ = p[1];
+				p += 2;
+				continue;
+			}
+		} else if (*p == ';') {	/* next parameter */
+			break;
+		}
+
+		if (out && out < out_end)
+			*out++ = *p;
+		p++;
+	}
+
+	if (out)
+		*out = 0;
+	*pp = p;
+}
+
+/*
+ * Parse one header value of the form "<main> [; <name>=<value> ...]".
+ * Copy <main> (up to the first ';', trimmed) into main_val when non-NULL.
+ * Then, for each parameter whose name matches an entry of params, copy its
+ * decoded value into that entry's dest.  Stops at the end of the line.
+ */
+void
+http_header_params(const char *h, char *main_val, size_t main_len,
+		   struct header_params *params, size_t nparams)
+{
+	const char *end = h + strcspn(h, "\n");
+	const char *p = h;
+
+	if (main_val && main_len) {
+		const char *m = p + strspn(p, " \t");	/* skip leading space */
+		size_t len = strcspn(m, ";");
+
+		if (m + len > end)
+			len = end - m;
+		while (len && (m[len - 1] == ' ' || m[len - 1] == '\t'))
+			len--;
+		if (len >= main_len)
+			len = main_len - 1;
+		memcpy(main_val, m, len);
+		main_val[len] = 0;
+	}
+	p += strcspn(p, ";");
+
+	while (p < end && *p == ';') {
+		p++;				/* skip ';' */
+		p += strspn(p, " \t");		/* skip whitespace */
+
+		const char *name = p;
+		p += strcspn(p, "=;\n");
+		const char *name_end = p;
+
+		while (name_end > name &&
+		       (name_end[-1] == ' ' || name_end[-1] == '\t'))
+			name_end--;		/* trim trailing whitespace */
+
+		if (p < end && *p == '=') {	/* has a value */
+			p++;
+			p += strspn(p, " \t");
+
+			char *dest = NULL;
+			size_t length = 0;
+			const size_t name_len = (size_t)(name_end - name);
+
+			for (size_t i = 0; i < nparams; i++)
+				if (strlen(params[i].name) == name_len &&
+				    strncasecmp(params[i].name, name,
+						name_len) == 0) {
+					dest = params[i].dest;
+					length = params[i].length;
+					break;
+				}
+
+			http_param_value(&p, end, dest, length);
+		}
+		/* else: a bare parameter (no '=') or the end of the line; the
+		   loop's `*p == ';'` test skips it / exits. */
+	}
+}

--- a/src/http_params.h
+++ b/src/http_params.h
@@ -1,0 +1,65 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2001-2007 Wilmer van der Gaast
+  Copyright 2008      Y Giridhar Appaji Nag
+  Copyright 2008-2009 Philipp Hagemeister
+  Copyright 2015      Joao Eriberto Mota Filho
+  Copyright 2016      Ivan Gimenez
+  Copyright 2016      Phillip Berndt
+  Copyright 2016      Sjjad Hashemian
+  Copyright 2016      Stephen Thirlwall
+  Copyright 2017      Antonio Quartulli
+  Copyright 2017      David Polverari
+  Copyright 2017-2019 Ismael Luceno
+  Copyright 2018-2019 Shankar
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/* HTTP header parameter parsing */
+
+#ifndef AXEL_HTTP_PARAMS_H
+#define AXEL_HTTP_PARAMS_H
+
+#include <stddef.h>
+
+/* One parameter to pull out of a semicolon-separated header value. */
+struct header_params {
+	const char *name;	/* parameter name, matched case-insensitively */
+	char *dest;		/* output buffer, or NULL to skip the value */
+	size_t length;		/* size of dest */
+};
+
+void http_header_params(const char *h, char *main_val, size_t main_len,
+			struct header_params *params, size_t nparams);
+
+#endif				/* AXEL_HTTP_PARAMS_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 # One binary per suite: harness.h keeps its registry in file-scope statics,
 # so two suites linked together would leave one of them unreachable.
-TEST_SUITES = test/netrc test/conf
+TEST_SUITES = test/netrc test/conf test/http
 
 # Some properties of the tree are invisible to a program compiled from it:
 # how long its files are, and whether they are compiled at all.  These suites
@@ -35,6 +35,14 @@ test_conf_SOURCES = \
 test_conf_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
 test_conf_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 test_conf_LDADD = $(LIBOBJS) $(LIBINTL) $(PTHREAD_LIBS)
+
+test_http_SOURCES = \
+	test/harness.h \
+	test/http.c \
+	src/http_params.c
+test_http_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
+test_http_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+test_http_LDADD = $(LIBOBJS) $(PTHREAD_LIBS)
 
 test_tap_run_SOURCES = test/tap-run.c
 

--- a/test/http.c
+++ b/test/http.c
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Axel contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * test/http.c — HTTP header parameter parsing tests
+ *
+ * http_header_params() has to tell a quoted semicolon from a real parameter
+ * separator and honour backslash escapes inside quotes.  The cases below are
+ * the ones that used to come out wrong.
+ */
+
+#include "config.h"
+
+#include "harness.h"
+
+#include <string.h>
+
+#include "http_params.h"
+
+/* Parse a synthetic header value and pull out the filename parameter. */
+static void
+parse(const char *value, char *out, size_t len)
+{
+	struct header_params params[] = {
+		{ "filename", out, len },
+	};
+
+	*out = 0;
+	http_header_params(value, NULL, 0, params, 1);
+}
+
+/* ── the value and its delimiters ─────────────────────────────────────── */
+
+TEST(a_quoted_semicolon_stays_in_the_value)
+{
+	char out[64];
+
+	parse("attachment; filename=\"a;b.jpg\"", out, sizeof(out));
+	CHECK_STR(out, "a;b.jpg");
+}
+
+TEST(an_unquoted_value_stops_at_the_semicolon)
+{
+	char out[64];
+
+	parse("attachment; filename=a;b.jpg", out, sizeof(out));
+	CHECK_STR(out, "a");
+}
+
+TEST(a_backslash_escape_is_decoded)
+{
+	char out[64];
+
+	parse("attachment; filename=\"a\\\"b.jpg\"", out, sizeof(out));
+	CHECK_STR(out, "a\"b.jpg");
+}
+
+TEST(single_quotes_delimit_like_double_quotes)
+{
+	char out[64];
+
+	parse("attachment; filename='a;b.jpg'", out, sizeof(out));
+	CHECK_STR(out, "a;b.jpg");
+}
+
+/* ── picking the parameter out of a list ──────────────────────────────── */
+
+TEST(filename_is_found_among_other_parameters)
+{
+	char out[64];
+
+	parse("attachment; size=123; filename=\"x.jpg\"; foo=bar", out,
+	      sizeof(out));
+	CHECK_STR(out, "x.jpg");
+}
+
+TEST(a_trailing_semicolon_is_ignored)
+{
+	char out[64];
+
+	parse("attachment; filename=\"x.jpg\";", out, sizeof(out));
+	CHECK_STR(out, "x.jpg");
+}
+
+/* ── when there is nothing to find ────────────────────────────────────── */
+
+TEST(a_value_without_filename_leaves_the_buffer_alone)
+{
+	char out[64];
+	struct header_params params[] = {
+		{ "filename", out, sizeof(out) },
+	};
+
+	strcpy(out, "unchanged");
+	http_header_params("attachment; size=123", NULL, 0, params, 1);
+	CHECK_STR(out, "unchanged");
+}
+
+/* ── the leading main value ───────────────────────────────────────────── */
+
+TEST(the_main_value_is_captured_when_asked)
+{
+	char main_val[64];
+	char out[64];
+	struct header_params params[] = {
+		{ "filename", out, sizeof(out) },
+	};
+
+	http_header_params("attachment; filename=\"x.jpg\"", main_val,
+			   sizeof(main_val), params, 1);
+	CHECK_STR(main_val, "attachment");
+	CHECK_STR(out, "x.jpg");
+}
+
+int
+main(void)
+{
+	REGISTER_DESC(a_quoted_semicolon_stays_in_the_value,
+		      "a quoted semicolon stays inside the value");
+	REGISTER_DESC(an_unquoted_value_stops_at_the_semicolon,
+		      "an unquoted value ends at the first semicolon");
+	REGISTER_DESC(a_backslash_escape_is_decoded,
+		      "a backslash-escaped quote is decoded");
+	REGISTER_DESC(single_quotes_delimit_like_double_quotes,
+		      "single quotes delimit like double quotes");
+	REGISTER_DESC(filename_is_found_among_other_parameters,
+		      "filename is picked out from among other parameters");
+	REGISTER_DESC(a_trailing_semicolon_is_ignored,
+		      "a trailing semicolon after the value is ignored");
+	REGISTER_DESC(a_value_without_filename_leaves_the_buffer_alone,
+		      "a value with no filename leaves the caller's buffer alone");
+	REGISTER_DESC(the_main_value_is_captured_when_asked,
+		      "the leading main value is captured when a buffer is given");
+
+	RUN_ALL();
+	return DONE();
+}


### PR DESCRIPTION
## Summary
- replace the `sscanf`-based filename extraction with a parameter parser that handles quoted values
- correctly keep semicolons inside quoted `filename` values (for example: `filename=foo;bar`)
- preserve existing filename sanitization and trimming behavior after parsing

## Notes
- this addresses the behavior discussed in #431 and in the linked PR #430 comment

Closes #431