### PR TITLE
Fix axelrc parsing for interfaces list values

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -142,9 +142,10 @@ conf_loadfile(conf_t *conf, const char *file)
 		/* Skip the "=" and any spaces following it */
 		while (isspace(*++tmp));	/* XXX isspace('\0') is false */
 		value = tmp;
-		/* Get to the end of the value string */
-		while (*tmp && !isspace(*tmp))
-			tmp++;
+		/* Trim trailing spaces without truncating list-like values */
+		tmp = value + strlen(value);
+		while (tmp > value && isspace((unsigned char)tmp[-1]))
+			tmp--;
 		*tmp = '\0';
 
 		/* String options */


### PR DESCRIPTION
## Summary
- preserve the full config value after = instead of truncating at first whitespace
- trim only trailing whitespace from config values
- this allows interfaces = ip1 ip2 ip3 to be parsed as an actual list

## Why
Issue #401 reports that interfaces appears to do nothing. The parser currently truncates values at the first space, so only the first token survives.

Closes #401