### PR TITLE
Avoid integer overflow in year 2038

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -100,7 +100,7 @@ typedef struct {
 	tcp_t *tcp;
 	bool enabled;
 	bool supported;
-	int last_transfer;
+	long long last_transfer;
 	char *message;
 	char *local_if;
 


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Year_2038_problem

If ABI-compatibility is a concern, `unsigned int` could instead be used as a type to work until year 2106.

This patch was done while reviewing potential year-2038 issues in openSUSE.