### PR TITLE
Fix resumed connections never starting on macOS

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -206,9 +206,10 @@ axel_new(conf_t *conf, int count, const search_t *res)
 /* Grow or shrink the array of connections, zeroing whatever is added.
  *
  * Only the entries past the end are cleared: the ones already there keep the
- * lock axel_new() initialised for them.  A connection a state file adds gets
- * a zeroed lock instead, which works because that is what an unlocked mutex
- * is on the platforms this runs on, and because nothing has taken it yet. */
+ * lock axel_new() initialised for them.  The added entries get their lock
+ * initialised explicitly: a zeroed pthread_mutex_t is not a valid mutex on
+ * every platform (e.g. macOS), and pthread_mutex_trylock() on one fails with
+ * EINVAL forever, which permanently disables those connections. */
 int
 axel_conn_resize(axel_t *axel, uint16_t nconns)
 {
@@ -219,9 +220,12 @@ axel_conn_resize(axel_t *axel, uint16_t nconns)
 		return 0;
 
 	axel->conn = new_conn;
-	if (nconns > oldconns)
+	if (nconns > oldconns) {
 		memset(axel->conn + oldconns, 0,
 		       sizeof(conn_t) * (nconns - oldconns));
+		for (uint16_t i = oldconns; i < nconns; i++)
+			pthread_mutex_init(&axel->conn[i].lock, NULL);
+	}
 
 	axel->conf->num_connections = nconns;
 	return 1;


### PR DESCRIPTION
**Summary**

On macOS, resuming a multi-connection download from a `.st` state file silently disables every connection except the first one, no matter what `-n` is given. In the common case the download crawls along on connection 0 alone; when connection 0 happens to have no work left in the state file (e.g. its range is already complete), the resumed download sits at 0 bytes/s forever. Linux is unaffected, which is presumably why this was never caught.

**Root cause**

`axel_open()` reallocates the conn array to the `num_connections` stored in the state file and then zeroes `conn[1..n-1]` with `memset()`, which destroys the pthread mutexes initialized in `axel_new()` (and when the stored count exceeds the current `-n`, the grown tail of the array never had initialized mutexes at all). On glibc a zero-filled `pthread_mutex_t` happens to be identical to `PTHREAD_MUTEX_INITIALIZER`, so the bug is invisible on Linux. On macOS a zeroed mutex is invalid: `pthread_mutex_lock()` in `setup_thread()` fails with `EINVAL` (return value unchecked, so setup proceeds and even sets `enabled = true`), and every `pthread_mutex_trylock()` in `axel_do()` also returns `EINVAL`, which the main loop interprets as "setup thread still holds the lock". Connections 1..n-1 are therefore never added to the `select()` set, never read, and never reconnected, while the servers' responses pile up unread (CLOSE_WAIT sockets with full receive queues).

**Steps to reproduce**

Tested on macOS Tahoe 26.4.1 (Darwin 25.4.0), MacBook Pro M4 Max, with axel 2.17.14 from Homebrew. The bug has two visible forms depending on the state of connection 0 in the `.st` file; both are reproduced below. Note that `conn[0]` itself never dies — the `memset` starts at `conn + 1` — which is what makes form A easy to miss.

*Form A — resume silently degrades to a single connection (any interrupted download):*

```
axel -n4 -o /tmp/u.iso https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-live-server-amd64.iso
# Ctrl-C after a few seconds; /tmp/u.iso.st is saved
axel -n4 -o /tmp/u.iso https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-live-server-amd64.iso
# let it resume for ~25 s, Ctrl-C again, compare the .st before/after
```

The state file is `uint16 nconn`, `uint64 bytes_done`, then per connection `uint64 currentbyte`, `uint64 lastbyte`. Comparing `currentbyte` before and after the resume session:

| connection | before resume | after 25 s resume (2.17.14) | after 25 s resume (this patch) |
|---|---|---|---|
| conn 0 | 9,699,328 | 215,438,336 (+205.7 MB) | +53 MB |
| conn 1 | 835,567,616 | **unchanged** | +53 MB |
| conn 2 | 1,674,626,048 | **unchanged** | +53 MB |
| conn 3 | 2,487,284,736 | **unchanged** | +53 MB |

On a fast mirror this is easy to misread as a working resume, because connection 0 alone can saturate the link, and once it finishes its own range it keeps stealing work from the dead connections via `reactivate_connection()`, so the download even completes eventually — just with no parallelism. The dead connections only show up in the `.st` offsets or in `lsof` (their sockets eventually go CLOSE_WAIT with data stuck in the receive queue).

*Form B — permanent stall at 0 bytes/s:* if `conn[0]`'s range is already complete in the state file and every remaining range is smaller than `MIN_CHUNK_WORTH` (100 KB), `reactivate_connection()` finds nothing for connection 0 to steal, so the only live connection has no work and nothing moves at all. Starting from form A's `.st`, mark conn 0 finished and shrink the other ranges to 50,000 bytes each:

```python
import struct
d = bytearray(open('/tmp/u.iso.st','rb').read())
n = struct.unpack_from('<H', d, 0)[0]
size = 3303444480  # file size
for i in range(n):
    cur, last = struct.unpack_from('<QQ', d, 10 + i*16)
    struct.pack_into('<QQ', d, 10 + i*16, last if i == 0 else last - 50000, last)
struct.pack_into('<Q', d, 2, size - (n - 1)*50000)
open('/tmp/u.iso.st','wb').write(d)
```

Resuming this with 2.17.14 reports `Downloaded 0 byte(s) in 24 second(s)` and would sit there forever; with this patch the same state finishes in about a second (`Downloaded 146.484 Kilobyte(s)`, exactly the 3×50,000 missing bytes) and the state file is removed.

**Real-world case**

This was tracked down from a 125.7 GB archive.org download whose state file had 29 small remaining ranges and a finished connection 0: every resume attempt sat at 0 bytes/s indefinitely (the process alive in `axel_do → axel_sleep`, all sockets CLOSE_WAIT, ~53 KB unread in each receive queue). Instrumenting 2.17.14 showed all 29 setup threads completing with HTTP 206 and `enabled = true`, while `pthread_mutex_trylock(&conn[i].lock)` returned 22 (`EINVAL`) for every `i >= 1` on each main-loop iteration — `conn[0]`, whose mutex survives because the `memset` starts at `conn + 1`, returned 0. With this patch the same state file resumed instantly and the completed file matched the publisher's MD5.

**Fix**

Initialize the mutexes of the entries `axel_conn_resize()` adds.

(Updated after rebasing onto current master: the analysis above describes 2.17.14, where `axel_open()` wiped `conn[1..n-1]`. The state-file code has since moved to `stfile_load()`, and `axel_conn_resize()` only zeroes the entries it adds, so existing connections now keep the locks `axel_new()` initialized — which already fixes the reproductions above when the same `-n` is used. What remains broken is the growth path: a state file storing more connections than the current `-n` allocated leaves the added entries with zero-filled locks. The repros above still trigger it on macOS when resumed with a smaller `-n`, e.g. `-n2`.)

