### PR TITLE
Fix building with gettext files >= 0.24

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,7 @@ AS_IF([test "x$with_ssl" != xno], [
 
 # Add Gettext
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.11.1])
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.6])
 
 # POSIX threads
 AX_PTHREAD()


### PR DESCRIPTION
This fixes #478.

`AM_GNU_GETTEXT_REQUIRE_VERSION` was added in gettext 0.19.6 (released in September 2015).