### PR TITLE
conn: derive output filename from decoded path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,14 @@ SUBDIRS = po
 
 EXTRA_DIST = \
 	scripts/pocheck.awk \
+	tests/config.h \
+	tests/test-path-traversal.c \
+	tests/test-path-traversal.sh \
 	README.md \
 	CONTRIBUTING.md
+
+check-local:
+	$(SHELL) $(top_srcdir)/tests/test-path-traversal.sh
 
 include doc/Makefile.am
 

--- a/src/axel.c
+++ b/src/axel.c
@@ -184,8 +184,8 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	axel->conn[0].local_if = axel->conf->interfaces->text;
 	axel->conf->interfaces = axel->conf->interfaces->next;
 
-	strlcpy(axel->filename, axel->conn[0].file, sizeof(axel->filename));
-	http_decode(axel->filename);
+	conn_output_filename(&axel->conn[0], axel->filename,
+			     sizeof(axel->filename));
 
 	if ((s = strchr(axel->filename, '?')) != NULL &&
 	    axel->conf->strip_cgi_parameters)
@@ -243,8 +243,8 @@ axel_new(conf_t *conf, int count, const search_t *res)
 
 	/* Wildcards in URL --> Get complete filename */
 	if (axel->filename[strcspn(axel->filename, "*?")])
-		strlcpy(axel->filename, axel->conn[0].file,
-			sizeof(axel->filename));
+		conn_output_filename(&axel->conn[0], axel->filename,
+				     sizeof(axel->filename));
 
 	if (*axel->conn[0].output_filename != 0) {
 		strlcpy(axel->filename, axel->conn[0].output_filename,

--- a/src/conn.c
+++ b/src/conn.c
@@ -167,6 +167,24 @@ conn_set(conn_t *conn, const char *set_url)
 	return conn->port > 0;
 }
 
+void
+conn_output_filename(const conn_t *conn, char *dst, size_t size)
+{
+	char path[MAX_STRING];
+	char *end;
+	char *sep;
+
+	snprintf(path, sizeof(path), "%s%s", conn->dir, conn->file);
+	http_decode(path);
+
+	end = path + strlen(path);
+	while (end > path + 1 && end[-1] == '/')
+		*--end = 0;
+
+	sep = strrchr(path, '/');
+	strlcpy(dst, sep ? sep + 1 : path, size);
+}
+
 const char *
 scheme_from_proto(int proto)
 {

--- a/src/conn.h
+++ b/src/conn.h
@@ -110,6 +110,7 @@ typedef struct {
 } conn_t;
 
 int conn_set(conn_t *conn, const char *set_url);
+void conn_output_filename(const conn_t *conn, char *dst, size_t size);
 int conn_url(char *dst, size_t len, conn_t *conn);
 void conn_disconnect(conn_t *conn);
 int conn_init(conn_t *conn);

--- a/tests/config.h
+++ b/tests/config.h
@@ -1,0 +1,2 @@
+#define ARCH "test"
+#define VERSION "test"

--- a/tests/test-path-traversal.c
+++ b/tests/test-path-traversal.c
@@ -1,0 +1,47 @@
+#include "axel.h"
+
+int
+main(void)
+{
+	conn_t conn = {0};
+	char filename[MAX_STRING];
+
+	if (!conn_set(&conn, "http://127.0.0.1/%2e%2e%2fpwned.txt"))
+		return 1;
+
+	conn_output_filename(&conn, filename, sizeof(filename));
+	if (strcmp(filename, "pwned.txt") != 0) {
+		fprintf(stderr, "expected pwned.txt, got %s\n", filename);
+		return 1;
+	}
+
+	if (!conn_set(&conn, "http://127.0.0.1/%252e%252e%252fpwned.txt"))
+		return 1;
+
+	conn_output_filename(&conn, filename, sizeof(filename));
+	if (strcmp(filename, "%2e%2e%2fpwned.txt") != 0) {
+		fprintf(stderr, "expected %%2e%%2e%%2fpwned.txt, got %s\n",
+			filename);
+		return 1;
+	}
+
+	if (!conn_set(&conn, "http://127.0.0.1/path%2finner%2ffile.txt?token=1"))
+		return 1;
+
+	conn_output_filename(&conn, filename, sizeof(filename));
+	if (strcmp(filename, "file.txt?token=1") != 0) {
+		fprintf(stderr, "expected file.txt?token=1, got %s\n", filename);
+		return 1;
+	}
+
+	if (!conn_set(&conn, "http://127.0.0.1/dir%2f"))
+		return 1;
+
+	conn_output_filename(&conn, filename, sizeof(filename));
+	if (strcmp(filename, "dir") != 0) {
+		fprintf(stderr, "expected dir, got %s\n", filename);
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/test-path-traversal.sh
+++ b/tests/test-path-traversal.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+srcdir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+top_srcdir="$(CDPATH= cd -- "$srcdir/.." && pwd)"
+builddir="$(mktemp -d)"
+binary="$builddir/test-path-traversal"
+
+cleanup()
+{
+	rm -rf "$builddir"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+cc -ffunction-sections -fdata-sections -Wl,--gc-sections \
+	-I"$srcdir" -I"$top_srcdir" -I"$top_srcdir/src" \
+	-o "$binary" \
+	"$srcdir/test-path-traversal.c" \
+	"$top_srcdir/src/conn.c" \
+	"$top_srcdir/src/http.c" \
+	"$top_srcdir/lib/strlcpy.c" \
+	"$top_srcdir/lib/strlcat.c"
+
+"$binary"


### PR DESCRIPTION
## Summary

- derive the local output filename from the decoded URL path basename
- prevent percent-decoded path separators from creating traversal paths on disk
- add a regression test for encoded-separator filename handling

## Root Cause

`conn_set()` splits the URL path before percent-decoding, so encoded separators like `%2f` remain embedded in `conn->file`. Later, `axel_new()` copied `conn->file` into `axel->filename` and called `http_decode()` on the local output name, which could turn those encoded separators into `/` too late and allow path traversal in the chosen download filename.

## Fix

- add `conn_output_filename()` to derive the local filename from the decoded full path basename only
- switch `axel_new()` to use that helper instead of decoding `conn->file` directly
- keep the wildcard refresh path aligned with the same safe filename derivation
- handle decoded trailing slash cases like `/dir%2f` by preserving the final basename as `dir`
- wire in a regression test script for the traversal cases

## Verification

```sh
sh tests/test-path-traversal.sh
sh /home/uos/Downloads/axel/tests/test-path-traversal.sh
cc -c -Itests -I. -Isrc src/axel.c src/conn.c src/http.c
```

## Related

Closes #477