### PR TITLE
test: Fix tap-run compilation on macOS

### DIFF
--- a/test/tap-run.c
+++ b/test/tap-run.c
@@ -22,8 +22,7 @@
  * Compile with: gcc -std=c99 -O2 -o tap-run tap-run.c
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L   /* for asprintf, strdup, posix_spawn, etc. */
+#define _GNU_SOURCE   /* asprintf on glibc; implies POSIX.1-2008 there */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,7 +36,9 @@
 #include <sys/uio.h>
 #include <sys/wait.h>
 
-/* POSIX.1-2008 declares environ in <unistd.h> */
+/* POSIX leaves environ for the application to declare: glibc puts it
+ * in <unistd.h> only under _GNU_SOURCE, macOS in no header at all. */
+extern char **environ;
 
 #ifndef IOV_MAX
 # define IOV_MAX 1024


### PR DESCRIPTION
`make check` does not compile on macOS: `test/tap-run.c` fails with `use of undeclared identifier 'asprintf'` and, later, `'environ'`.

The cause is the `_POSIX_C_SOURCE` define: on macOS it puts the headers into strict POSIX mode (`__DARWIN_C_LEVEL` drops below `__DARWIN_C_FULL`), which hides `asprintf()`, and `_GNU_SOURCE` means nothing there. Dropping it changes nothing on glibc — `_GNU_SOURCE` already implies POSIX.1-2008 — while the macOS default exposes the full API. `environ` is declared by no macOS header at all, and glibc declares it in `<unistd.h>` only under `_GNU_SOURCE`; POSIX leaves the declaration to the application, so the patch declares it explicitly (the comment it replaces assumed `<unistd.h>` provides it).

With this, `make check` passes on macOS (Darwin 25.5, Apple clang): 152 tests, 0 failures.
