### PR TITLE
Fix macOS -Werror builds and compile the checkout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@
 # tree and out of an unpacked tarball, so it also answers whether the
 # distribution carries everything the suites read -- which two of them
 # read the source tree for.
+#
+# A plain make from the checkout runs before it: the unpacked tarball has
+# no .git, AX_IS_RELEASE calls it a release, and -Werror stays off there,
+# so only an in-tree build catches warning regressions.
 name: CI
 
 on:
@@ -53,6 +57,11 @@ jobs:
       - name: configure
         run: ./configure ${{ matrix.ssl }}
 
+      # From the checkout, so AX_IS_RELEASE has -Werror on -- the build
+      # inside distcheck runs in release mode and never sees warnings
+      - name: make
+        run: make
+
       # The inner configure takes no flags of its own, so without this
       # every job would distcheck the default build
       - name: distcheck
@@ -90,4 +99,6 @@ jobs:
               CFLAGS="$CFLAGS -I$GETTEXT/include -I$OPENSSL/include" \
               LDFLAGS="-L$GETTEXT/lib" \
               PKG_CONFIG_PATH="$OPENSSL/lib/pkgconfig"
+          # in-tree first: this is the only -Werror build (see header)
+          make
           make DIST_TARGETS=dist-gzip GZIP_ENV=--fast distcheck

--- a/src/axel.c
+++ b/src/axel.c
@@ -180,7 +180,7 @@ axel_new(conf_t *conf, int count, const search_t *res)
 			char hsize[32];
 			axel_size_human(hsize, sizeof(hsize), axel->size);
 			axel_message(axel, _("File size: %s (%jd bytes)"),
-				     hsize, axel->size);
+				     hsize, (intmax_t)axel->size);
 		} else {
 			axel_message(axel, _("File size: unavailable"));
 		}
@@ -854,8 +854,8 @@ axel_divide(axel_t *axel)
 #ifndef NDEBUG
 	for (int i = 0; i < axel->conf->num_connections; i++) {
 		printf(_("Downloading %jd-%jd using conn. %i\n"),
-		       axel->conn[i].currentbyte,
-		       axel->conn[i].lastbyte, i);
+		       (intmax_t)axel->conn[i].currentbyte,
+		       (intmax_t)axel->conn[i].lastbyte, i);
 	}
 #endif
 }

--- a/src/axel.h
+++ b/src/axel.h
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <netinet/in_systm.h>

--- a/src/conn.c
+++ b/src/conn.c
@@ -297,7 +297,8 @@ conn_setup(conn_t *conn)
 		conn->tcp = &conn->ftp->data_tcp;
 
 		if (conn->currentbyte) {
-			ftp_command(conn->ftp, "REST %jd", conn->currentbyte);
+			ftp_command(conn->ftp, "REST %jd",
+				    (intmax_t)conn->currentbyte);
 			if (ftp_wait(conn->ftp) / 100 != 3 &&
 			    conn->ftp->status / 100 != 2)
 				return 0;

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -116,7 +116,7 @@ ftp_cwd(ftp_t *conn, char *cwd)
 off_t
 ftp_size(ftp_t *conn, char *file, int maxredir, unsigned io_timeout)
 {
-	off_t i, j, size = MAX_STRING;
+	intmax_t i, j, size = MAX_STRING;
 	char *reply, *s, fn[MAX_STRING];
 
 	/* Try the SIZE command first, if possible */

--- a/src/http.c
+++ b/src/http.c
@@ -391,20 +391,6 @@ decode_nibble(char n)
 	return n - 'A' + 10;
 }
 
-inline static char
-encode_nibble(char n)
-{
-	return n > 9 ? n + 'a' - 10 : n + '0';
-}
-
-inline static void
-encode_byte(char dst[3], char n)
-{
-	*dst++ = '%';
-	*dst++ = encode_nibble(n >> 4);
-	*dst = encode_nibble(n & 15);
-}
-
 /* Decode%20a%20file%20name */
 void
 http_decode(char *s)

--- a/src/http.c
+++ b/src/http.c
@@ -192,10 +192,11 @@ http_get(http_t *conn, char *lurl)
 	http_addheader(conn, "Accept-Encoding: identity");
 	if (conn->lastbyte && conn->firstbyte >= 0) {
 		http_addheader(conn, "Range: bytes=%jd-%jd",
-			       conn->firstbyte, conn->lastbyte - 1);
+			       (intmax_t)conn->firstbyte,
+			       (intmax_t)(conn->lastbyte - 1));
 	} else if (conn->firstbyte >= 0) {
 		http_addheader(conn, "Range: bytes=%jd-",
-			       conn->firstbyte);
+			       (intmax_t)conn->firstbyte);
 	}
 }
 
@@ -319,7 +320,7 @@ off_t
 http_size(http_t *conn)
 {
 	const char *i;
-	off_t j;
+	intmax_t j;
 
 	if ((i = http_header(conn, "Content-Length:")) == NULL)
 		return -2;

--- a/src/search.c
+++ b/src/search.c
@@ -132,7 +132,7 @@ search_makelist(search_t *results, char *orig_url)
 		 /* Num. of results: */ "m=%i&"
 		 /* Size (min/max):  */ "s1=%jd&s2=%jd",
 		 conn->file, results->conf->search_amount,
-		 conn->size, conn->size);
+		 (intmax_t)conn->size, (intmax_t)conn->size);
 
 	conn_disconnect(conn);
 	memset(conn, 0, sizeof(conn_t));

--- a/src/stfile.c
+++ b/src/stfile.c
@@ -208,7 +208,8 @@ stfile_load(axel_t *axel)
 
 	axel_message(axel,
 		     _("State file found: %jd bytes downloaded, %jd to go."),
-		     axel->bytes_done, axel->size - axel->bytes_done);
+		     (intmax_t)axel->bytes_done,
+		     (intmax_t)(axel->size - axel->bytes_done));
 
 	return 1;
 }

--- a/src/text.c
+++ b/src/text.c
@@ -369,7 +369,7 @@ axel_setup(conf_t *conf, int do_search, char *s, int argc, char *argv[])
 		printf("%-60s %15s\n", "URL", _("Speed"));
 		for (i = 0; i < j; i++)
 			printf("%-70.70s %5jd\n", search[i].url,
-			       search[i].speed);
+			       (intmax_t)search[i].speed);
 		printf("\n");
 	}
 	axel = axel_new(conf, j, search);


### PR DESCRIPTION
A git-checkout build (where `AX_IS_RELEASE` turns `-Werror` on) does not compile on macOS. clang flags every `%jd` conversion passed an `off_t` — the two are distinct types there, `off_t` being `long long` while `intmax_t` is `long` — and the unused `encode_byte()` left behind when the URL encoding was removed in cc14be8 (gcc keeps quiet about unused `inline static` functions, clang does not). The casts are more than warning hygiene: passing the wrong type to a variadic function is undefined behavior even where the sizes happen to match.

The first two commits fix that: the dead helpers go away, printf-style arguments get an `(intmax_t)` cast, the sscanf targets are read into `intmax_t` variables, and `<stdint.h>` joins the axel.h includes. Twelve call sites across eight files; no behavior change on LP64 Linux, where both types are `long`.

The third commit closes the gap that let these accumulate: distcheck builds inside the unpacked tarball, where `AX_IS_RELEASE` sees no `.git` and `-Werror` stays off, so CI has never compiled anything with the warnings a developer build gets. Every job now runs a plain `make` from the checkout before distcheck, so warning regressions fail the run. (Until the runners' autoconf catches up with the required 2.72 the Linux jobs stop at autoreconf anyway, but the macos job exercises the new step immediately.)

Verified on macOS (Darwin 25.5, Apple clang): the in-tree `-Werror` build now compiles, and multi-connection downloads work. Verified on Linux in a debian:trixie container (autoconf 2.72): in-tree `-Werror` builds pass with CI's `CFLAGS="-Os -fPIC"` for both gcc 14 and clang 19, and `make check` passes 152/152. At `-Os` gcc prints a few `-Winline` notes about pre-existing `inline static` helpers it declines to inline; those are not promoted to errors and do not fail the build.

Independent of #484; together they make `make && make check` from a git checkout work on macOS.
