### PR TITLE
ci: Turn on -Werror inside the distcheck build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@
 # tree and out of an unpacked tarball, so it also answers whether the
 # distribution carries everything the suites read -- which two of them
 # read the source tree for.
+#
+# --enable-compile-warnings=error is passed to the inner configure so that
+# build, the only one distcheck does, runs with -Werror: AX_IS_RELEASE
+# leaves it off by default once the tree has no .git, which is always true
+# inside the unpacked distribution.
 name: CI
 
 on:
@@ -57,7 +62,7 @@ jobs:
       # every job would distcheck the default build
       - name: distcheck
         run: >
-          make DIST_TARGETS=dist-gzip GZIP_ENV=--fast DISTCHECK_CONFIGURE_FLAGS="${{ matrix.ssl }}" distcheck
+          make DIST_TARGETS=dist-gzip GZIP_ENV=--fast DISTCHECK_CONFIGURE_FLAGS="${{ matrix.ssl }} --enable-compile-warnings=error" distcheck
 
       # distcheck runs the suites inside the unpacked distribution, and
       # takes it away again on the way out, so the raw TAP has to be
@@ -90,4 +95,5 @@ jobs:
               CFLAGS="$CFLAGS -I$GETTEXT/include -I$OPENSSL/include" \
               LDFLAGS="-L$GETTEXT/lib" \
               PKG_CONFIG_PATH="$OPENSSL/lib/pkgconfig"
-          make DIST_TARGETS=dist-gzip GZIP_ENV=--fast distcheck
+          make DIST_TARGETS=dist-gzip GZIP_ENV=--fast \
+              DISTCHECK_CONFIGURE_FLAGS="--enable-compile-warnings=error" distcheck

--- a/test/harness.h
+++ b/test/harness.h
@@ -127,6 +127,7 @@ static volatile sig_atomic_t _h_timed_out;
  * run therefore leaks, and any later test relying on shared global state may
  * be unreliable.  That is an acceptable trade here: the alternative is the
  * suite producing no result at all. */
+static void _h_on_alarm(int sig) __attribute__((noreturn));
 static void _h_on_alarm(int sig) {
     (void)sig;
     _h_timed_out = 1;

--- a/test/tap-run.c
+++ b/test/tap-run.c
@@ -22,8 +22,7 @@
  * Compile with: gcc -std=c99 -O2 -o tap-run tap-run.c
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L   /* for asprintf, strdup, posix_spawn, etc. */
+#define _GNU_SOURCE   /* asprintf on glibc; implies POSIX.1-2008 there */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,7 +36,9 @@
 #include <sys/uio.h>
 #include <sys/wait.h>
 
-/* POSIX.1-2008 declares environ in <unistd.h> */
+/* POSIX leaves environ for the application to declare: glibc puts it
+ * in <unistd.h> only under _GNU_SOURCE, macOS in no header at all. */
+extern char **environ;
 
 #ifndef IOV_MAX
 # define IOV_MAX 1024


### PR DESCRIPTION
Following up on the discussion in #485: distcheck is the only build CI ever runs, and it builds inside an unpacked tarball with no `.git`, so `AX_IS_RELEASE` calls it a release and `-Werror` never turns on there, no matter what the outer configure step was given. `--enable-compile-warnings=error` in `DISTCHECK_CONFIGURE_FLAGS` fixes that without a second build: distcheck's own build just runs with `-Werror`.

Turning that on surfaced one thing beyond what #485 already covers: `test/harness.h`'s `_h_on_alarm()` always `siglongjmp()`s and never returns, but nothing told the compiler that, so clang's `-Wmissing-noreturn` fails the build over it (gcc doesn't warn here, which is why it went unnoticed). Marked it `noreturn`; no other function in the suites has this shape.

This also carries over the `test/tap-run.c` fix from #484 (same commit, cherry-picked verbatim), since without it distcheck fails on `asprintf`/`environ` before ever reaching the warnings flag — the two commits are both prerequisites for this one to demonstrate anything. Closing #484 as superseded by this PR; happy to reopen it standalone if you'd rather land these separately.

Verified end to end on macOS (Darwin 25.5, Apple clang) with `make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-ssl --enable-compile-warnings=error"`: unpack, build, `make check`, and packaging all pass clean.
