### PR TITLE
Fix TCP connection timeout handling

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -77,6 +77,33 @@ tcp_error(char *hostname, int port, const char *reason)
 		hostname, port, reason);
 }
 
+int
+tcp_wait_for_connection(int sock_fd, unsigned io_timeout)
+{
+	fd_set fdset;
+	struct timeval tout = { .tv_sec = io_timeout };
+	socklen_t error_len;
+	int error;
+	int ret;
+
+	FD_ZERO(&fdset);
+	FD_SET(sock_fd, &fdset);
+	ret = select(sock_fd + 1, NULL, &fdset, NULL, &tout);
+	if (ret <= 0)
+		return ret;
+
+	error = 0;
+	error_len = sizeof(error);
+	if (getsockopt(sock_fd, SOL_SOCKET, SO_ERROR, &error, &error_len))
+		return -1;
+	if (error) {
+		errno = error;
+		return -1;
+	}
+
+	return 1;
+}
+
 /* Get a TCP connection */
 int
 tcp_connect(tcp_t *tcp, char *hostname, int port, int secure, char *local_if,
@@ -138,7 +165,8 @@ tcp_connect(tcp_t *tcp, char *hostname, int port, int secure, char *local_if,
 			tcp_fastopen = setsockopt(sock_fd, IPPROTO_TCP,
 						  TCP_FASTOPEN_CONNECT,
 						  NULL, 0);
-		} else if (io_timeout) {
+		}
+		if (tcp_fastopen == -1 && io_timeout) {
 			/* Set O_NONBLOCK so we can timeout */
 			fcntl(sock_fd, F_SETFL, O_NONBLOCK);
 		}
@@ -156,15 +184,13 @@ tcp_connect(tcp_t *tcp, char *hostname, int port, int secure, char *local_if,
 		if (tcp_fastopen != -1)
 			break;
 
-		/* Wait for the connection */
-		fd_set fdset;
-		FD_ZERO(&fdset);
-		FD_SET(sock_fd, &fdset);
-		struct timeval tout = { .tv_sec  = io_timeout };
-		ret = select(sock_fd + 1, NULL, &fdset, NULL, &tout);
-		/* Success? */
-		if (ret != -1)
+		ret = tcp_wait_for_connection(sock_fd, io_timeout);
+		if (ret > 0)
 			break;
+		if (ret == 0)
+			errno = ETIMEDOUT;
+		close(sock_fd);
+		sock_fd = -1;
 	} while ((gai_result = gai_result->ai_next));
 
 	freeaddrinfo(gai_results);

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -62,6 +62,7 @@ typedef struct {
 } tcp_t;
 
 int is_ipv6_addr(const char *hostname);
+int tcp_wait_for_connection(int sock_fd, unsigned io_timeout);
 int tcp_connect(tcp_t *tcp, char *hostname, int port, int secure,
 		char *local_if, unsigned io_timeout);
 void tcp_close(tcp_t *tcp);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 # One binary per suite: harness.h keeps its registry in file-scope statics,
 # so two suites linked together would leave one of them unreachable.
-TEST_SUITES = test/netrc test/conf
+TEST_SUITES = test/netrc test/conf test/tcp
 
 # Some properties of the tree are invisible to a program compiled from it:
 # how long its files are, and whether they are compiled at all.  These suites
@@ -35,6 +35,22 @@ test_conf_SOURCES = \
 test_conf_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
 test_conf_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 test_conf_LDADD = $(LIBOBJS) $(LIBINTL) $(PTHREAD_LIBS)
+
+test_tcp_SOURCES = \
+	test/harness.h \
+	test/tcp.c \
+	src/tcp.c
+test_tcp_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
+test_tcp_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+test_tcp_LDADD = $(LIBOBJS) $(LIBINTL) $(PTHREAD_LIBS)
+
+if WITH_SSL
+test_tcp_SOURCES += \
+	src/dn-match.c \
+	src/ssl.c \
+	src/ssl_verify.c
+test_tcp_LDADD += $(SSL_LIBS)
+endif
 
 test_tap_run_SOURCES = test/tap-run.c
 

--- a/test/tcp.c
+++ b/test/tcp.c
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright 2026 Mohammad Yousaf <myousaf64@users.noreply.github.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * test/tcp.c - TCP connection wait tests.
+ *
+ * A non-blocking connect makes a socket writable for both success and
+ * failure.  tcp_wait_for_connection must read SO_ERROR before it accepts
+ * that readiness.  A full socket buffer also provides a local timeout case
+ * without depending on a network route that can change under the test.
+ */
+
+#include "config.h"
+
+#include "harness.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "axel.h"
+
+static void
+close_pair(int pair[2])
+{
+	close(pair[0]);
+	close(pair[1]);
+}
+
+TEST(a_writable_socket_reports_a_completed_connection)
+{
+	int pair[2];
+
+	ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pair), 0);
+	ASSERT_EQ(tcp_wait_for_connection(pair[0], 0), 1);
+	close_pair(pair);
+}
+
+TEST(a_full_socket_buffer_reports_a_timeout)
+{
+	char buffer[4096] = { 0 };
+	int flags;
+	int pair[2];
+	ssize_t written;
+
+	ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pair), 0);
+	flags = fcntl(pair[0], F_GETFL);
+	ASSERT_NE(flags, -1);
+	ASSERT_EQ(fcntl(pair[0], F_SETFL, flags | O_NONBLOCK), 0);
+
+	for (;;) {
+		written = write(pair[0], buffer, sizeof(buffer));
+		if (written >= 0)
+			continue;
+		ASSERT(errno == EAGAIN || errno == EWOULDBLOCK);
+		break;
+	}
+
+	ASSERT_EQ(tcp_wait_for_connection(pair[0], 0), 0);
+	close_pair(pair);
+}
+
+TEST(a_refused_connection_reports_the_socket_error)
+{
+	struct sockaddr_in address;
+	socklen_t address_len;
+	int flags;
+	int listener;
+	int ret;
+	int socket_fd;
+
+	listener = socket(AF_INET, SOCK_STREAM, 0);
+	ASSERT_NE(listener, -1);
+	memset(&address, 0, sizeof(address));
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	ASSERT_EQ(bind(listener, (struct sockaddr *)&address, sizeof(address)), 0);
+	ASSERT_EQ(listen(listener, 1), 0);
+	address_len = sizeof(address);
+	ASSERT_EQ(getsockname(listener, (struct sockaddr *)&address, &address_len), 0);
+	close(listener);
+
+	socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+	ASSERT_NE(socket_fd, -1);
+	flags = fcntl(socket_fd, F_GETFL);
+	ASSERT_NE(flags, -1);
+	ASSERT_EQ(fcntl(socket_fd, F_SETFL, flags | O_NONBLOCK), 0);
+	ret = connect(socket_fd, (struct sockaddr *)&address, sizeof(address));
+	ASSERT_EQ(ret, -1);
+	if (errno == EINPROGRESS) {
+		ASSERT_EQ(tcp_wait_for_connection(socket_fd, 1), -1);
+		ASSERT_EQ(errno, ECONNREFUSED);
+	} else {
+		ASSERT_EQ(errno, ECONNREFUSED);
+	}
+	close(socket_fd);
+}
+
+int
+main(void)
+{
+	REGISTER_DESC(a_writable_socket_reports_a_completed_connection,
+		      "a writable socket with no error reports a completed connection");
+	REGISTER_DESC(a_full_socket_buffer_reports_a_timeout,
+		      "a socket that cannot become writable reports a timeout");
+	REGISTER_DESC(a_refused_connection_reports_the_socket_error,
+		      "a refused connection reports its socket error");
+	RUN_ALL();
+	return DONE();
+}


### PR DESCRIPTION
Fixes #421

## Summary

- Enable the non-blocking connection fallback when TCP Fast Open is unavailable.
- Treat a timed-out `select()` call as `ETIMEDOUT`.
- Read `SO_ERROR` before accepting a writable socket as connected.
- Add local socket tests for completion, timeout, and refusal.

## Tests

`make check`

Result: 158 passed, 0 failed.

I configured the build with `--disable-Werror` because GCC 15 reports existing ignored-result warnings outside this change.