### PR TITLE
Drop credentials after untrusted redirects

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -405,7 +405,7 @@ void
 conf_auth_setup(conf_t *conf, int proto, const char *host,
 		char *user, size_t user_len, char *pass, size_t pass_len)
 {
-	if (*user || *pass)
+	if (*user || *pass || (conf && conf->untrusted_host))
 		return;
 
 	netrc_parse(conf ? conf->netrc : NULL, host, user, user_len,

--- a/src/conn.c
+++ b/src/conn.c
@@ -436,13 +436,18 @@ conn_redirect(conn_t *conn, const char *url)
 	if (!conn_set(conn, url))
 		return 0;
 
-	if (conn->conf->location_trusted || conn->conf->untrusted_host)
+	if (conn->conf->location_trusted)
 		return 1;
+	if (conn->conf->untrusted_host) {
+		*conn->user = *conn->pass = 0;
+		return 1;
+	}
 
 	if (conf_credentials_may_follow(proto, host, conn->proto, conn->host))
 		return 1;
 
 	conn->conf->untrusted_host = true;
+	*conn->user = *conn->pass = 0;
 	if (conf_has_private_headers(conn->conf))
 		fprintf(stderr, _("Redirected away from the host asked for, "
 				  "not passing on the headers that carry "


### PR DESCRIPTION
Axel could resend netrc credentials after a redirect changed the host or downgraded HTTPS to HTTP. The redirect guard only suppressed custom private headers, while connection setup could reload credentials and generate Authorization.

This patch marks such redirects untrusted, clears in-memory credentials, and prevents netrc authentication from being reloaded for subsequent connections.