### PR TITLE
http: Support filename* in Content-Disposition

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,8 @@ axel_SOURCES = \
 	src/hash.h \
 	src/http.c \
 	src/http.h \
+	src/http_params.c \
+	src/http_params.h \
 	src/netrc.c \
 	src/netrc.h \
 	src/random.c \

--- a/src/conn.c
+++ b/src/conn.c
@@ -11,6 +11,7 @@
   Copyright 2017      Antonio Quartulli
   Copyright 2017-2018 Ismael Luceno
   Copyright 2018      Shankar
+  Copyright 2026      kyomoto-omarchy <2028566723@qq.com>
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -48,6 +49,7 @@
 #include "config.h"
 #include "axel.h"
 #include "hash.h"
+#include "http.h"
 
 /**
  * Convert an URL to a conn_t structure.
@@ -455,6 +457,9 @@ conn_redirect(conn_t *conn, const char *url)
 int
 conn_info(conn_t *conn)
 {
+  /* A redirect or a previous protocol must not leave its filename here */
+  conn->output_filename[0] = '\0';
+
 	/* It's all a bit messed up.. But it works. */
 	if (PROTO_IS_FTP(conn->proto) && !conn->proxy) {
 		return conn_info_ftp(conn);
@@ -477,8 +482,6 @@ conn_info(conn_t *conn)
 			return 0;
 		conn_exec(conn);
 		conn_disconnect(conn);
-
-		http_filename(conn->http, conn->output_filename);
 
 		/* Code 3xx == redirect */
 		if (conn->http->status / 100 != 3)
@@ -527,6 +530,9 @@ conn_info(conn_t *conn)
 	/* Check for non-recoverable errors */
 	if (conn->http->status != 416 && conn->http->status / 100 != 2)
 		return 0;
+
+  http_filename(conn->http, conn->output_filename,
+                sizeof(conn->output_filename));
 
 	conn->size = http_size_from_range(conn->http);
 	/* We assume partial requests are supported if a Content-Range

--- a/src/http.c
+++ b/src/http.c
@@ -371,7 +371,7 @@ http_size_from_range(http_t *conn)
 void
 http_filename(const http_t *conn, char *filename, size_t size)
 {
-  const char *header = http_header(conn, "Content-Disposition");
+  const char *header = http_header(conn, "Content-Disposition:");
 
   http_content_disposition_filename(header, filename, size);
 }

--- a/src/http.c
+++ b/src/http.c
@@ -13,6 +13,7 @@
   Copyright 2017      David Polverari
   Copyright 2017-2019 Ismael Luceno
   Copyright 2018-2019 Shankar
+  Copyright 2026      kyomoto-omarchy <2028566723@qq.com>
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -49,6 +50,7 @@
 
 #include "config.h"
 #include "axel.h"
+#include "http_params.h"
 
 #define HDR_CHUNK 512
 #define MAX_HEADERS (64 * 1024)
@@ -367,30 +369,11 @@ http_size_from_range(http_t *conn)
  * Content-Disposition: attachment; filename="filename.jpg"
  */
 void
-http_filename(const http_t *conn, char *filename)
+http_filename(const http_t *conn, char *filename, size_t size)
 {
-	const char *h;
-	if ((h = http_header(conn, "Content-Disposition:")) != NULL) {
-		sscanf(h, "%*s%*[ \t]filename%*[ \t=\"\'-]%254[^;\n\"\']",
-		       filename);
-		/* Trim spaces at the end of string */
-		const char space[] = "\t ";
-		for (char *n, *p = filename; (p = strpbrk(p, space)); p = n) {
-			n = p + strspn(p, space);
-			if (!*n) {
-				*p = 0;
-				break;
-			}
-		}
+  const char *header = http_header(conn, "Content-Disposition");
 
-		/* Replace common invalid characters in filename
-		   https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words */
-		const char invalid[] = "/\\?%*:|<>";
-		const char replacement = '_';
-		for (char *i = filename; (i = strpbrk(i, invalid)); i++) {
-			*i = replacement;
-		}
-	}
+  http_content_disposition_filename(header, filename, size);
 }
 
 inline static char

--- a/src/http.h
+++ b/src/http.h
@@ -8,6 +8,7 @@
   Copyright 2016      Stephen Thirlwall
   Copyright 2017      Antonio Quartulli
   Copyright 2017-2019 Ismael Luceno
+  Copyright 2026      kyomoto-omarchy <2028566723@qq.com>
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -70,7 +71,7 @@ __attribute__((format(printf, 2, 3)))
 void http_addheader(http_t *conn, const char *format, ...);
 int http_exec(http_t *conn);
 const char *http_header(const http_t *conn, const char *header);
-void http_filename(const http_t *conn, char *filename);
+void http_filename(const http_t *conn, char *filename, size_t size);
 off_t http_size(http_t *conn);
 off_t http_size_from_range(http_t *conn);
 void http_decode(char *s);

--- a/src/http_params.c
+++ b/src/http_params.c
@@ -41,6 +41,7 @@
 
 #include "http_params.h"
 
+#include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 
@@ -185,6 +186,196 @@ bool http_copy_parameter(char *dest, size_t size,
     j++;
   }
   dest[j] = '\0';
+
+  return true;
+}
+
+// transfer a ASCII hex char to 0-15. return -1 if it is not a hex char
+static int hexadecimal_value(unsigned char c) {
+  if ('0' <= c && c <= '9')
+    return c - '0';
+  if ('A' <= c && c <= 'F')
+    return c - 'A' + 10;
+  if ('a' <= c && c <= 'f')
+    return c - 'a' + 10;
+
+  return -1;
+}
+
+static bool is_attribute_character(unsigned char c) {
+  if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
+      ('0' <= c && c <= '9'))
+    return true;
+
+  switch (c) {
+  case '!':
+  case '#':
+  case '$':
+  case '&':
+  case '+':
+  case '-':
+  case '.':
+  case '^':
+  case '_':
+  case '`':
+  case '|':
+  case '~':
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool read_extended_byte(const char **cursor, const char *end,
+                               unsigned char *byte) {
+  const char *p = *cursor;
+
+  if (p == end)
+    return false;
+
+  if (*p == '%') {
+    int high;
+    int low;
+
+    if (end - p < 3)
+      return false;
+
+    high = hexadecimal_value((unsigned char)p[1]);
+    low = hexadecimal_value((unsigned char)p[2]);
+    if (high < 0 || low < 0)
+      return false;
+
+    *byte = (unsigned char)((high << 4) | low);
+    p += 3;
+  } else {
+    *byte = (unsigned char)*p;
+    if (!is_attribute_character(*byte))
+      return false;
+
+    p++;
+  }
+
+  if (*byte == 0)
+    return false;
+
+  *cursor = p;
+  return true;
+}
+
+// language can be empty
+static bool is_language(const char *start, const char *end) {
+  for (const char *p = start; p < end; p++) {
+    unsigned char c = (unsigned char)*p;
+
+    if (!(('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
+          ('0' <= c && c <= '9') || c == '-'))
+      return false;
+  }
+
+  return true;
+}
+
+static bool read_continuation_byte(const char **cursor, const char *end,
+                                   unsigned char *byte, size_t *length) {
+  if (!read_extended_byte(cursor, end, byte) || (*byte & 0xc0) != 0x80)
+    return false;
+
+  (*length)++;
+  return true;
+}
+
+static bool validate_extended_utf8(const char *start, const char *end,
+                                   size_t *length) {
+  const char *p = start;
+  size_t decoded_length = 0;
+
+  while (p < end) {
+    unsigned char first;
+    unsigned char second;
+    unsigned char third;
+    unsigned char fourth;
+
+    if (!read_extended_byte(&p, end, &first))
+      return false;
+    decoded_length++;
+
+    if (first <= 0x7f)
+      continue;
+
+    if (first >= 0xc2 && first <= 0xdf) {
+      if (!read_continuation_byte(&p, end, &second, &decoded_length))
+        return false;
+      continue;
+    }
+
+    if (first >= 0xe0 && first <= 0xef) {
+      if (!read_continuation_byte(&p, end, &second, &decoded_length) ||
+          !read_continuation_byte(&p, end, &third, &decoded_length))
+        return false;
+
+      if ((first == 0xe0 && second < 0xa0) || (first == 0xed && second > 0x9f))
+        return false;
+      continue;
+    }
+
+    if (first >= 0xf0 && first <= 0xf4) {
+      if (!read_continuation_byte(&p, end, &second, &decoded_length) ||
+          !read_continuation_byte(&p, end, &third, &decoded_length) ||
+          !read_continuation_byte(&p, end, &fourth, &decoded_length))
+        return false;
+
+      if ((first == 0xf0 && second < 0x90) || (first == 0xf4 && second > 0x8f))
+        return false;
+      continue;
+    }
+
+    return false;
+  }
+
+  *length = decoded_length;
+  return true;
+}
+
+bool http_decode_extended_parameter(char *dest, size_t size,
+                                    const struct http_parameter *parameter) {
+  const char *charset_end;
+  const char *language_end;
+  const char *value_start;
+  const char *end;
+  const char *p;
+  size_t decoded_length;
+  size_t output = 0;
+
+  if (!dest || !size || !parameter || !parameter->value || parameter->quoted)
+    return false;
+
+  end = parameter->value + parameter->length;
+  charset_end = memchr(parameter->value, '\'', parameter->length);
+  if (!charset_end)
+    return false;
+
+  language_end = memchr(charset_end + 1, '\'', (size_t)(end - charset_end - 1));
+  if (!language_end)
+    return false;
+
+  if ((size_t)(charset_end - parameter->value) != 5 ||
+      strncasecmp(parameter->value, "UTF-8", 5) != 0 ||
+      !is_language(charset_end + 1, language_end))
+    return false;
+
+  value_start = language_end + 1;
+  if (!validate_extended_utf8(value_start, end, &decoded_length) ||
+      decoded_length >= size)
+    return false;
+
+  for (p = value_start; p < end;) {
+    unsigned char byte;
+
+    if (!read_extended_byte(&p, end, &byte))
+      return false;
+    dest[output++] = (char)byte;
+  }
+  dest[output] = '\0';
 
   return true;
 }

--- a/src/http_params.c
+++ b/src/http_params.c
@@ -1,0 +1,190 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2026 kyomoto-omarchy <2028566723@qq.com>
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ USA.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/* HTTP response header parameter parsing. */
+
+#include "config.h"
+
+#include "http_params.h"
+
+#include <string.h>
+#include <strings.h>
+
+static const char *skip_whitespace(const char *p, const char *end) {
+  while (p < end && (*p == ' ' || *p == '\t'))
+    p++;
+
+  return p;
+}
+
+bool http_find_parameter(const char *header, const char *name,
+                         struct http_parameter *parameter) {
+  const char *end;
+  const char *p;
+  size_t wanted_length;
+
+  if (!header || !name || !*name || !parameter) {
+    return false;
+  }
+
+  end = header + strcspn(header, "\r\n");
+  wanted_length = strlen(name);
+  p = header;
+
+  // NOTE: skip attachment
+  while (p < end && *p != ';') {
+    p++;
+  }
+
+  while (p < end) {
+    const char *name_start;
+    const char *name_end;
+    const char *value_start;
+    const char *value_end;
+    bool quoted = false;
+    bool valid = true;
+
+    p++; // skip ';'
+    p = skip_whitespace(p, end);
+    name_start = p;
+
+    while (p < end && *p != '=' && *p != ';')
+      p++;
+
+    name_end = p;
+    while (name_end > name_start &&
+           (name_end[-1] == ' ' || name_end[-1] == '\t')) {
+      name_end--;
+    }
+
+    if (p == end)
+      break;
+    if (*p == ';')
+      continue;
+
+    p++;
+    p = skip_whitespace(p, end);
+
+    if (p < end && *p == '"') {
+      quoted = true;
+      p++;
+      value_start = p;
+
+      while (p < end && *p != '"') {
+        if (*p == '\\') {
+          if (p + 1 == end) {
+            valid = false;
+            p = end;
+            break;
+          }
+          p += 2;
+        } else {
+          p++;
+        }
+      }
+
+      value_end = p;
+      if (p == end) {
+        valid = false;
+      } else {
+        p++;
+        p = skip_whitespace(p, end);
+
+        if (p < end && *p != ';') {
+          valid = false;
+          while (p < end && *p != ';') {
+            p++;
+          }
+        }
+      }
+    } else {
+      value_start = p;
+      while (p < end && *p != ';')
+        p++;
+
+      value_end = p;
+      while (value_end > value_start &&
+             (value_end[-1] == ' ' || value_end[-1] == '\t')) {
+        value_end--;
+      }
+    }
+
+    if (valid && (size_t)(name_end - name_start) == wanted_length &&
+        strncasecmp(name_start, name, wanted_length) == 0) {
+      parameter->value = value_start;
+      parameter->length = (size_t)(value_end - value_start);
+      parameter->quoted = quoted;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool http_copy_parameter(char *dest, size_t size,
+                         const struct http_parameter *parameter) {
+  size_t output_length = 0;
+  size_t i;
+  size_t j;
+
+  if (!dest || !size || !parameter || !parameter->value)
+    return false;
+
+  for (i = 0; i < parameter->length; i++) {
+    if (parameter->quoted && parameter->value[i] == '\\') {
+      i++;
+      if (i == parameter->length)
+        return false;
+    }
+
+    output_length++;
+  }
+
+  if (output_length >= size)
+    return false;
+
+  for (i = 0, j = 0; i < parameter->length; i++) {
+    if (parameter->quoted && parameter->value[i] == '\\')
+      i++;
+
+    dest[j] = parameter->value[i];
+    j++;
+  }
+  dest[j] = '\0';
+
+  return true;
+}

--- a/src/http_params.c
+++ b/src/http_params.c
@@ -379,3 +379,45 @@ bool http_decode_extended_parameter(char *dest, size_t size,
 
   return true;
 }
+
+static bool sanitize_filename(char *filename) {
+  static const char invalid[] = "/\\?%*:|<>\"";
+
+  char *end = filename + strlen(filename);
+
+  while (end > filename && (end[-1] == ' ' || end[-1] == '\t'))
+    *--end = '\0';
+
+  for (unsigned char *p = (unsigned char *)filename; *p; p++) {
+    if (*p < 0x20 || *p == 0x7f || strchr(invalid, (char)*p) != NULL)
+      *p = '_';
+  }
+
+  return *filename && strcmp(filename, ".") != 0 && strcmp(filename, "..") != 0;
+}
+
+bool http_content_disposition_filename(const char *header, char *filename,
+                                       size_t size) {
+  struct http_parameter parameter;
+
+  if (!filename || !size)
+    return false;
+
+  filename[0] = '\0';
+  if (!header)
+    return false;
+
+  if (http_find_parameter(header, "filename*", &parameter) &&
+      http_decode_extended_parameter(filename, size, &parameter) &&
+      sanitize_filename(filename))
+    return true;
+
+  filename[0] = '\0';
+  if (http_find_parameter(header, "filename", &parameter) &&
+      http_copy_parameter(filename, size, &parameter) &&
+      sanitize_filename(filename))
+    return true;
+
+  filename[0] = '\0';
+  return false;
+}

--- a/src/http_params.c
+++ b/src/http_params.c
@@ -45,379 +45,414 @@
 #include <string.h>
 #include <strings.h>
 
-static const char *skip_whitespace(const char *p, const char *end) {
-  while (p < end && (*p == ' ' || *p == '\t'))
-    p++;
+static const char *
+skip_whitespace(const char *p, const char *end)
+{
+	while (p < end && (*p == ' ' || *p == '\t'))
+		p++;
 
-  return p;
+	return p;
 }
 
-bool http_find_parameter(const char *header, const char *name,
-                         struct http_parameter *parameter) {
-  const char *end;
-  const char *p;
-  size_t wanted_length;
+bool
+http_find_parameter(const char *header, const char *name,
+		    struct http_parameter *parameter)
+{
+	const char *end;
+	const char *p;
+	size_t wanted_length;
 
-  if (!header || !name || !*name || !parameter) {
-    return false;
-  }
+	if (!header || !name || !*name || !parameter) {
+		return false;
+	}
 
-  end = header + strcspn(header, "\r\n");
-  wanted_length = strlen(name);
-  p = header;
+	end = header + strcspn(header, "\r\n");
+	wanted_length = strlen(name);
+	p = header;
 
-  // NOTE: skip attachment
-  while (p < end && *p != ';') {
-    p++;
-  }
+	// NOTE: skip attachment
+	while (p < end && *p != ';') {
+		p++;
+	}
 
-  while (p < end) {
-    const char *name_start;
-    const char *name_end;
-    const char *value_start;
-    const char *value_end;
-    bool quoted = false;
-    bool valid = true;
+	while (p < end) {
+		const char *name_start;
+		const char *name_end;
+		const char *value_start;
+		const char *value_end;
+		bool quoted = false;
+		bool valid = true;
 
-    p++; // skip ';'
-    p = skip_whitespace(p, end);
-    name_start = p;
+		p++;		// skip ';'
+		p = skip_whitespace(p, end);
+		name_start = p;
 
-    while (p < end && *p != '=' && *p != ';')
-      p++;
+		while (p < end && *p != '=' && *p != ';')
+			p++;
 
-    name_end = p;
-    while (name_end > name_start &&
-           (name_end[-1] == ' ' || name_end[-1] == '\t')) {
-      name_end--;
-    }
+		name_end = p;
+		while (name_end > name_start &&
+		       (name_end[-1] == ' ' || name_end[-1] == '\t')) {
+			name_end--;
+		}
 
-    if (p == end)
-      break;
-    if (*p == ';')
-      continue;
+		if (p == end)
+			break;
+		if (*p == ';')
+			continue;
 
-    p++;
-    p = skip_whitespace(p, end);
+		p++;
+		p = skip_whitespace(p, end);
 
-    if (p < end && *p == '"') {
-      quoted = true;
-      p++;
-      value_start = p;
+		if (p < end && *p == '"') {
+			quoted = true;
+			p++;
+			value_start = p;
 
-      while (p < end && *p != '"') {
-        if (*p == '\\') {
-          if (p + 1 == end) {
-            valid = false;
-            p = end;
-            break;
-          }
-          p += 2;
-        } else {
-          p++;
-        }
-      }
+			while (p < end && *p != '"') {
+				if (*p == '\\') {
+					if (p + 1 == end) {
+						valid = false;
+						p = end;
+						break;
+					}
+					p += 2;
+				} else {
+					p++;
+				}
+			}
 
-      value_end = p;
-      if (p == end) {
-        valid = false;
-      } else {
-        p++;
-        p = skip_whitespace(p, end);
+			value_end = p;
+			if (p == end) {
+				valid = false;
+			} else {
+				p++;
+				p = skip_whitespace(p, end);
 
-        if (p < end && *p != ';') {
-          valid = false;
-          while (p < end && *p != ';') {
-            p++;
-          }
-        }
-      }
-    } else {
-      value_start = p;
-      while (p < end && *p != ';')
-        p++;
+				if (p < end && *p != ';') {
+					valid = false;
+					while (p < end && *p != ';') {
+						p++;
+					}
+				}
+			}
+		} else {
+			value_start = p;
+			while (p < end && *p != ';')
+				p++;
 
-      value_end = p;
-      while (value_end > value_start &&
-             (value_end[-1] == ' ' || value_end[-1] == '\t')) {
-        value_end--;
-      }
-    }
+			value_end = p;
+			while (value_end > value_start &&
+			       (value_end[-1] == ' '
+				|| value_end[-1] == '\t')) {
+				value_end--;
+			}
+		}
 
-    if (valid && (size_t)(name_end - name_start) == wanted_length &&
-        strncasecmp(name_start, name, wanted_length) == 0) {
-      parameter->value = value_start;
-      parameter->length = (size_t)(value_end - value_start);
-      parameter->quoted = quoted;
-      return true;
-    }
-  }
+		if (valid && (size_t) (name_end - name_start) == wanted_length
+		    && strncasecmp(name_start, name, wanted_length) == 0) {
+			parameter->value = value_start;
+			parameter->length = (size_t) (value_end - value_start);
+			parameter->quoted = quoted;
+			return true;
+		}
+	}
 
-  return false;
+	return false;
 }
 
-bool http_copy_parameter(char *dest, size_t size,
-                         const struct http_parameter *parameter) {
-  size_t output_length = 0;
-  size_t i;
-  size_t j;
+bool
+http_copy_parameter(char *dest, size_t size,
+		    const struct http_parameter *parameter)
+{
+	size_t output_length = 0;
+	size_t i;
+	size_t j;
 
-  if (!dest || !size || !parameter || !parameter->value)
-    return false;
+	if (!dest || !size || !parameter || !parameter->value)
+		return false;
 
-  for (i = 0; i < parameter->length; i++) {
-    if (parameter->quoted && parameter->value[i] == '\\') {
-      i++;
-      if (i == parameter->length)
-        return false;
-    }
+	for (i = 0; i < parameter->length; i++) {
+		if (parameter->quoted && parameter->value[i] == '\\') {
+			i++;
+			if (i == parameter->length)
+				return false;
+		}
 
-    output_length++;
-  }
+		output_length++;
+	}
 
-  if (output_length >= size)
-    return false;
+	if (output_length >= size)
+		return false;
 
-  for (i = 0, j = 0; i < parameter->length; i++) {
-    if (parameter->quoted && parameter->value[i] == '\\')
-      i++;
+	for (i = 0, j = 0; i < parameter->length; i++) {
+		if (parameter->quoted && parameter->value[i] == '\\')
+			i++;
 
-    dest[j] = parameter->value[i];
-    j++;
-  }
-  dest[j] = '\0';
+		dest[j] = parameter->value[i];
+		j++;
+	}
+	dest[j] = '\0';
 
-  return true;
+	return true;
 }
 
 // transfer a ASCII hex char to 0-15. return -1 if it is not a hex char
-static int hexadecimal_value(unsigned char c) {
-  if ('0' <= c && c <= '9')
-    return c - '0';
-  if ('A' <= c && c <= 'F')
-    return c - 'A' + 10;
-  if ('a' <= c && c <= 'f')
-    return c - 'a' + 10;
+static int
+hexadecimal_value(unsigned char c)
+{
+	if ('0' <= c && c <= '9')
+		return c - '0';
+	if ('A' <= c && c <= 'F')
+		return c - 'A' + 10;
+	if ('a' <= c && c <= 'f')
+		return c - 'a' + 10;
 
-  return -1;
+	return -1;
 }
 
-static bool is_attribute_character(unsigned char c) {
-  if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
-      ('0' <= c && c <= '9'))
-    return true;
+static bool
+is_attribute_character(unsigned char c)
+{
+	if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
+	    ('0' <= c && c <= '9'))
+		return true;
 
-  switch (c) {
-  case '!':
-  case '#':
-  case '$':
-  case '&':
-  case '+':
-  case '-':
-  case '.':
-  case '^':
-  case '_':
-  case '`':
-  case '|':
-  case '~':
-    return true;
-  default:
-    return false;
-  }
+	switch (c) {
+	case '!':
+	case '#':
+	case '$':
+	case '&':
+	case '+':
+	case '-':
+	case '.':
+	case '^':
+	case '_':
+	case '`':
+	case '|':
+	case '~':
+		return true;
+	default:
+		return false;
+	}
 }
 
-static bool read_extended_byte(const char **cursor, const char *end,
-                               unsigned char *byte) {
-  const char *p = *cursor;
+static bool
+read_extended_byte(const char **cursor, const char *end, unsigned char *byte)
+{
+	const char *p = *cursor;
 
-  if (p == end)
-    return false;
+	if (p == end)
+		return false;
 
-  if (*p == '%') {
-    int high;
-    int low;
+	if (*p == '%') {
+		int high;
+		int low;
 
-    if (end - p < 3)
-      return false;
+		if (end - p < 3)
+			return false;
 
-    high = hexadecimal_value((unsigned char)p[1]);
-    low = hexadecimal_value((unsigned char)p[2]);
-    if (high < 0 || low < 0)
-      return false;
+		high = hexadecimal_value((unsigned char) p[1]);
+		low = hexadecimal_value((unsigned char) p[2]);
+		if (high < 0 || low < 0)
+			return false;
 
-    *byte = (unsigned char)((high << 4) | low);
-    p += 3;
-  } else {
-    *byte = (unsigned char)*p;
-    if (!is_attribute_character(*byte))
-      return false;
+		*byte = (unsigned char) ((high << 4) | low);
+		p += 3;
+	} else {
+		*byte = (unsigned char) *p;
+		if (!is_attribute_character(*byte))
+			return false;
 
-    p++;
-  }
+		p++;
+	}
 
-  if (*byte == 0)
-    return false;
+	if (*byte == 0)
+		return false;
 
-  *cursor = p;
-  return true;
+	*cursor = p;
+	return true;
 }
 
 // language can be empty
-static bool is_language(const char *start, const char *end) {
-  for (const char *p = start; p < end; p++) {
-    unsigned char c = (unsigned char)*p;
+static bool
+is_language(const char *start, const char *end)
+{
+	for (const char *p = start; p < end; p++) {
+		unsigned char c = (unsigned char) *p;
 
-    if (!(('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
-          ('0' <= c && c <= '9') || c == '-'))
-      return false;
-  }
+		if (!(('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') ||
+		      ('0' <= c && c <= '9') || c == '-'))
+			return false;
+	}
 
-  return true;
+	return true;
 }
 
-static bool read_continuation_byte(const char **cursor, const char *end,
-                                   unsigned char *byte, size_t *length) {
-  if (!read_extended_byte(cursor, end, byte) || (*byte & 0xc0) != 0x80)
-    return false;
+static bool
+read_continuation_byte(const char **cursor, const char *end,
+		       unsigned char *byte, size_t *length)
+{
+	if (!read_extended_byte(cursor, end, byte) || (*byte & 0xc0) != 0x80)
+		return false;
 
-  (*length)++;
-  return true;
+	(*length)++;
+	return true;
 }
 
-static bool validate_extended_utf8(const char *start, const char *end,
-                                   size_t *length) {
-  const char *p = start;
-  size_t decoded_length = 0;
+static bool
+validate_extended_utf8(const char *start, const char *end, size_t *length)
+{
+	const char *p = start;
+	size_t decoded_length = 0;
 
-  while (p < end) {
-    unsigned char first;
-    unsigned char second;
-    unsigned char third;
-    unsigned char fourth;
+	while (p < end) {
+		unsigned char first;
+		unsigned char second;
+		unsigned char third;
+		unsigned char fourth;
 
-    if (!read_extended_byte(&p, end, &first))
-      return false;
-    decoded_length++;
+		if (!read_extended_byte(&p, end, &first))
+			return false;
+		decoded_length++;
 
-    if (first <= 0x7f)
-      continue;
+		if (first <= 0x7f)
+			continue;
 
-    if (first >= 0xc2 && first <= 0xdf) {
-      if (!read_continuation_byte(&p, end, &second, &decoded_length))
-        return false;
-      continue;
-    }
+		if (first >= 0xc2 && first <= 0xdf) {
+			if (!read_continuation_byte
+			    (&p, end, &second, &decoded_length))
+				return false;
+			continue;
+		}
 
-    if (first >= 0xe0 && first <= 0xef) {
-      if (!read_continuation_byte(&p, end, &second, &decoded_length) ||
-          !read_continuation_byte(&p, end, &third, &decoded_length))
-        return false;
+		if (first >= 0xe0 && first <= 0xef) {
+			if (!read_continuation_byte
+			    (&p, end, &second, &decoded_length)
+			    || !read_continuation_byte(&p, end, &third,
+						       &decoded_length))
+				return false;
 
-      if ((first == 0xe0 && second < 0xa0) || (first == 0xed && second > 0x9f))
-        return false;
-      continue;
-    }
+			if ((first == 0xe0 && second < 0xa0)
+			    || (first == 0xed && second > 0x9f))
+				return false;
+			continue;
+		}
 
-    if (first >= 0xf0 && first <= 0xf4) {
-      if (!read_continuation_byte(&p, end, &second, &decoded_length) ||
-          !read_continuation_byte(&p, end, &third, &decoded_length) ||
-          !read_continuation_byte(&p, end, &fourth, &decoded_length))
-        return false;
+		if (first >= 0xf0 && first <= 0xf4) {
+			if (!read_continuation_byte
+			    (&p, end, &second, &decoded_length)
+			    || !read_continuation_byte(&p, end, &third,
+						       &decoded_length)
+			    || !read_continuation_byte(&p, end, &fourth,
+						       &decoded_length))
+				return false;
 
-      if ((first == 0xf0 && second < 0x90) || (first == 0xf4 && second > 0x8f))
-        return false;
-      continue;
-    }
+			if ((first == 0xf0 && second < 0x90)
+			    || (first == 0xf4 && second > 0x8f))
+				return false;
+			continue;
+		}
 
-    return false;
-  }
+		return false;
+	}
 
-  *length = decoded_length;
-  return true;
+	*length = decoded_length;
+	return true;
 }
 
-bool http_decode_extended_parameter(char *dest, size_t size,
-                                    const struct http_parameter *parameter) {
-  const char *charset_end;
-  const char *language_end;
-  const char *value_start;
-  const char *end;
-  const char *p;
-  size_t decoded_length;
-  size_t output = 0;
+bool
+http_decode_extended_parameter(char *dest, size_t size,
+			       const struct http_parameter *parameter)
+{
+	const char *charset_end;
+	const char *language_end;
+	const char *value_start;
+	const char *end;
+	const char *p;
+	size_t decoded_length;
+	size_t output = 0;
 
-  if (!dest || !size || !parameter || !parameter->value || parameter->quoted)
-    return false;
+	if (!dest || !size || !parameter || !parameter->value
+	    || parameter->quoted)
+		return false;
 
-  end = parameter->value + parameter->length;
-  charset_end = memchr(parameter->value, '\'', parameter->length);
-  if (!charset_end)
-    return false;
+	end = parameter->value + parameter->length;
+	charset_end = memchr(parameter->value, '\'', parameter->length);
+	if (!charset_end)
+		return false;
 
-  language_end = memchr(charset_end + 1, '\'', (size_t)(end - charset_end - 1));
-  if (!language_end)
-    return false;
+	language_end =
+	    memchr(charset_end + 1, '\'', (size_t) (end - charset_end - 1));
+	if (!language_end)
+		return false;
 
-  if ((size_t)(charset_end - parameter->value) != 5 ||
-      strncasecmp(parameter->value, "UTF-8", 5) != 0 ||
-      !is_language(charset_end + 1, language_end))
-    return false;
+	if ((size_t) (charset_end - parameter->value) != 5 ||
+	    strncasecmp(parameter->value, "UTF-8", 5) != 0 ||
+	    !is_language(charset_end + 1, language_end))
+		return false;
 
-  value_start = language_end + 1;
-  if (!validate_extended_utf8(value_start, end, &decoded_length) ||
-      decoded_length >= size)
-    return false;
+	value_start = language_end + 1;
+	if (!validate_extended_utf8(value_start, end, &decoded_length) ||
+	    decoded_length >= size)
+		return false;
 
-  for (p = value_start; p < end;) {
-    unsigned char byte;
+	for (p = value_start; p < end;) {
+		unsigned char byte;
 
-    if (!read_extended_byte(&p, end, &byte))
-      return false;
-    dest[output++] = (char)byte;
-  }
-  dest[output] = '\0';
+		if (!read_extended_byte(&p, end, &byte))
+			return false;
+		dest[output++] = (char) byte;
+	}
+	dest[output] = '\0';
 
-  return true;
+	return true;
 }
 
-static bool sanitize_filename(char *filename) {
-  static const char invalid[] = "/\\?%*:|<>\"";
+static bool
+sanitize_filename(char *filename)
+{
+	static const char invalid[] = "/\\?%*:|<>\"";
 
-  char *end = filename + strlen(filename);
+	char *end = filename + strlen(filename);
 
-  while (end > filename && (end[-1] == ' ' || end[-1] == '\t'))
-    *--end = '\0';
+	while (end > filename && (end[-1] == ' ' || end[-1] == '\t'))
+		*--end = '\0';
 
-  for (unsigned char *p = (unsigned char *)filename; *p; p++) {
-    if (*p < 0x20 || *p == 0x7f || strchr(invalid, (char)*p) != NULL)
-      *p = '_';
-  }
+	for (unsigned char *p = (unsigned char *)filename; *p; p++) {
+		if (*p < 0x20 || *p == 0x7f
+		    || strchr(invalid, (char) *p) != NULL)
+			*p = '_';
+	}
 
-  return *filename && strcmp(filename, ".") != 0 && strcmp(filename, "..") != 0;
+	return *filename && strcmp(filename, ".") != 0
+	    && strcmp(filename, "..") != 0;
 }
 
-bool http_content_disposition_filename(const char *header, char *filename,
-                                       size_t size) {
-  struct http_parameter parameter;
+bool
+http_content_disposition_filename(const char *header, char *filename,
+				  size_t size)
+{
+	struct http_parameter parameter;
 
-  if (!filename || !size)
-    return false;
+	if (!filename || !size)
+		return false;
 
-  filename[0] = '\0';
-  if (!header)
-    return false;
+	filename[0] = '\0';
+	if (!header)
+		return false;
 
-  if (http_find_parameter(header, "filename*", &parameter) &&
-      http_decode_extended_parameter(filename, size, &parameter) &&
-      sanitize_filename(filename))
-    return true;
+	if (http_find_parameter(header, "filename*", &parameter) &&
+	    http_decode_extended_parameter(filename, size, &parameter) &&
+	    sanitize_filename(filename))
+		return true;
 
-  filename[0] = '\0';
-  if (http_find_parameter(header, "filename", &parameter) &&
-      http_copy_parameter(filename, size, &parameter) &&
-      sanitize_filename(filename))
-    return true;
+	filename[0] = '\0';
+	if (http_find_parameter(header, "filename", &parameter) &&
+	    http_copy_parameter(filename, size, &parameter) &&
+	    sanitize_filename(filename))
+		return true;
 
-  filename[0] = '\0';
-  return false;
+	filename[0] = '\0';
+	return false;
 }

--- a/src/http_params.h
+++ b/src/http_params.h
@@ -1,0 +1,57 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2026 kyomoto-omarchy <2028566723@qq.com>
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ USA.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/* HTTP response header parameter parsing. */
+
+#ifndef AXEL_HTTP_PARAMS_H
+#define AXEL_HTTP_PARAMS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+struct http_parameter {
+  const char *value;
+  size_t length;
+  bool quoted;
+};
+
+bool http_find_parameter(const char *header, const char *name,
+                         struct http_parameter *parameter);
+
+bool http_copy_parameter(char *dest, size_t size,
+                         const struct http_parameter *parameter);
+#endif /* AXEL_HTTP_PARAMS_H */

--- a/src/http_params.h
+++ b/src/http_params.h
@@ -54,4 +54,7 @@ bool http_find_parameter(const char *header, const char *name,
 
 bool http_copy_parameter(char *dest, size_t size,
                          const struct http_parameter *parameter);
+
+bool http_decode_extended_parameter(char *dest, size_t size,
+                         const struct http_parameter *parameter);
 #endif /* AXEL_HTTP_PARAMS_H */

--- a/src/http_params.h
+++ b/src/http_params.h
@@ -43,22 +43,23 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-struct http_parameter {
-  const char *value;
-  size_t length;
-  bool quoted;
+struct http_parameter
+{
+	const char *value;
+	size_t length;
+	bool quoted;
 };
 
 bool http_find_parameter(const char *header, const char *name,
-                         struct http_parameter *parameter);
+			 struct http_parameter *parameter);
 
 bool http_copy_parameter(char *dest, size_t size,
-                         const struct http_parameter *parameter);
+			 const struct http_parameter *parameter);
 
 bool http_decode_extended_parameter(char *dest, size_t size,
-                                    const struct http_parameter *parameter);
+				    const struct http_parameter *parameter);
 
 bool http_content_disposition_filename(const char *header, char *filename,
-                                       size_t size);
+				       size_t size);
 
 #endif /* AXEL_HTTP_PARAMS_H */

--- a/src/http_params.h
+++ b/src/http_params.h
@@ -56,5 +56,9 @@ bool http_copy_parameter(char *dest, size_t size,
                          const struct http_parameter *parameter);
 
 bool http_decode_extended_parameter(char *dest, size_t size,
-                         const struct http_parameter *parameter);
+                                    const struct http_parameter *parameter);
+
+bool http_content_disposition_filename(const char *header, char *filename,
+                                       size_t size);
+
 #endif /* AXEL_HTTP_PARAMS_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 # One binary per suite: harness.h keeps its registry in file-scope statics,
 # so two suites linked together would leave one of them unreachable.
-TEST_SUITES = test/netrc test/conf
+TEST_SUITES = test/netrc test/conf test/http_params
 
 # Some properties of the tree are invisible to a program compiled from it:
 # how long its files are, and whether they are compiled at all.  These suites
@@ -35,6 +35,15 @@ test_conf_SOURCES = \
 test_conf_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
 test_conf_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 test_conf_LDADD = $(LIBOBJS) $(LIBINTL) $(PTHREAD_LIBS)
+
+test_http_params_SOURCES = \
+	test/harness.h \
+	test/http_params.c \
+	src/http_params.c \
+	src/http_params.h
+test_http_params_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src
+test_http_params_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+test_http_params_LDADD = $(LIBOBJS) $(PTHREAD_LIBS)
 
 test_tap_run_SOURCES = test/tap-run.c
 

--- a/test/http_params.c
+++ b/test/http_params.c
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: Copyright 2026 kyomoto-omarchy <2028566723@qq.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * test/http_params.c -- HTTP header parameter parsing tests.
+ */
+
+#include "config.h"
+
+#include "harness.h"
+
+#include "http_params.h"
+
+/* Finding and copying ordinary parameters. */
+
+TEST(an_unquoted_parameter_is_found_and_copied) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+                             &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "a.txt");
+  CHECK(!parameter.quoted);
+  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "a.txt");
+}
+
+TEST(a_quoted_parameter_is_found_without_its_quotes) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename=\"a.txt\"", "filename",
+                             &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "a.txt");
+  CHECK(parameter.quoted);
+  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "a.txt");
+}
+
+TEST(parameter_names_ignore_case_and_surrounding_space) {
+  struct http_parameter parameter;
+
+  ASSERT(http_find_parameter("attachment ; FiLeNaMe \t= \t\"report.txt\"",
+                             "filename", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "report.txt");
+  CHECK(parameter.quoted);
+}
+
+TEST(a_parameter_name_must_match_in_full) {
+  struct http_parameter parameter;
+
+  ASSERT(
+      http_find_parameter("attachment; xfilename=wrong-1; filename*=wrong-2; "
+                          "filename=right.txt",
+                          "filename", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "right.txt");
+}
+
+TEST(an_extended_parameter_is_returned_in_its_raw_form) {
+  struct http_parameter parameter;
+
+  ASSERT(http_find_parameter("attachment; filename=a.txt; "
+                             "filename*=UTF-8''%E6%B5%8B%E8%AF%95.txt",
+                             "filename*", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length,
+             "UTF-8''%E6%B5%8B%E8%AF%95.txt");
+  CHECK(!parameter.quoted);
+}
+
+TEST(a_broken_segment_before_the_parameter_is_skipped) {
+  struct http_parameter parameter;
+
+  ASSERT(http_find_parameter("attachment; broken; filename=right.txt",
+                             "filename", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "right.txt");
+}
+
+/* Quoted-string delimiters and quoted-pairs. */
+
+TEST(a_semicolon_inside_quotes_belongs_to_the_value) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename=\"a;b.txt\"; size=123",
+                             "filename", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "a;b.txt");
+  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "a;b.txt");
+}
+
+TEST(quoted_pairs_are_unescaped_when_the_value_is_copied) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename=\"say \\\"hello\\\".txt\"",
+                             "filename", &parameter));
+  CHECK_LSTR(parameter.value, parameter.length, "say \\\"hello\\\".txt");
+  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "say \"hello\".txt");
+}
+
+TEST(an_unclosed_quoted_value_is_rejected) {
+  struct http_parameter parameter;
+
+  ASSERT(!http_find_parameter("attachment; filename=\"unterminated.txt",
+                              "filename", &parameter));
+}
+
+TEST(non_space_after_a_closing_quote_invalidates_the_parameter) {
+  struct http_parameter parameter;
+
+  ASSERT(!http_find_parameter("attachment; filename=\"bad.txt\"unexpected",
+                              "filename", &parameter));
+}
+
+/* Bounds and failure behaviour. */
+
+TEST(a_parameter_search_stops_at_the_end_of_the_header_line) {
+  struct http_parameter parameter;
+
+  ASSERT(!http_find_parameter(
+      "attachment; size=123\r\n"
+      "Content-Disposition: attachment; filename=next-line.txt\r\n",
+      "filename", &parameter));
+}
+
+TEST(a_missing_parameter_leaves_the_result_structure_unchanged) {
+  static const char marker[] = "unchanged";
+  struct http_parameter parameter = {
+      .value = marker,
+      .length = sizeof(marker) - 1,
+      .quoted = true,
+  };
+
+  ASSERT(!http_find_parameter("attachment; size=123", "filename", &parameter));
+  CHECK(parameter.value == marker);
+  CHECK_EQ(parameter.length, sizeof(marker) - 1);
+  CHECK(parameter.quoted);
+}
+
+TEST(a_small_destination_is_rejected_without_being_changed) {
+  struct http_parameter parameter;
+  char output[4] = "old";
+
+  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+                             &parameter));
+  ASSERT(!http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "old");
+}
+
+TEST(a_destination_with_exactly_enough_space_is_accepted) {
+  struct http_parameter parameter;
+  char output[sizeof("a.txt")];
+
+  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+                             &parameter));
+  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "a.txt");
+}
+
+int main(void) {
+  REGISTER_DESC(an_unquoted_parameter_is_found_and_copied,
+                "an unquoted parameter is found and copied");
+  REGISTER_DESC(a_quoted_parameter_is_found_without_its_quotes,
+                "a quoted parameter is returned without its quotes");
+  REGISTER_DESC(parameter_names_ignore_case_and_surrounding_space,
+                "parameter names ignore case and surrounding space");
+  REGISTER_DESC(a_parameter_name_must_match_in_full,
+                "a parameter name has to match in full");
+  REGISTER_DESC(an_extended_parameter_is_returned_in_its_raw_form,
+                "an extended parameter is returned without decoding");
+  REGISTER_DESC(a_broken_segment_before_the_parameter_is_skipped,
+                "a broken segment before a parameter is skipped");
+  REGISTER_DESC(a_semicolon_inside_quotes_belongs_to_the_value,
+                "a semicolon inside quotes belongs to the value");
+  REGISTER_DESC(quoted_pairs_are_unescaped_when_the_value_is_copied,
+                "quoted-pairs are unescaped when copied");
+  REGISTER_DESC(an_unclosed_quoted_value_is_rejected,
+                "an unclosed quoted value is rejected");
+  REGISTER_DESC(non_space_after_a_closing_quote_invalidates_the_parameter,
+                "non-space after a closing quote invalidates the parameter");
+  REGISTER_DESC(a_parameter_search_stops_at_the_end_of_the_header_line,
+                "a parameter search does not cross the header line");
+  REGISTER_DESC(a_missing_parameter_leaves_the_result_structure_unchanged,
+                "a failed search leaves its result structure unchanged");
+  REGISTER_DESC(a_small_destination_is_rejected_without_being_changed,
+                "a small destination is rejected without partial output");
+  REGISTER_DESC(a_destination_with_exactly_enough_space_is_accepted,
+                "a destination with room for the final NUL is accepted");
+
+  RUN_ALL();
+  return DONE();
+}

--- a/test/http_params.c
+++ b/test/http_params.c
@@ -157,6 +157,200 @@ TEST(a_destination_with_exactly_enough_space_is_accepted) {
   CHECK_STR(output, "a.txt");
 }
 
+/* RFC 8187 extended parameter decoding. */
+
+TEST(a_utf8_extended_parameter_is_percent_decoded) {
+  struct http_parameter parameter;
+  char output[64];
+
+  ASSERT(
+      http_find_parameter("attachment; "
+                          "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts",
+                          "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+}
+
+TEST(a_two_byte_utf8_character_is_percent_decoded) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8'fr'caf%C3%A9.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "caf\xC3\xA9.txt");
+}
+
+TEST(a_chinese_filename_is_percent_decoded) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; "
+                             "filename*=UTF-8'zh-CN'%E6%B5%8B%E8%AF%95.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "\xE6\xB5\x8B\xE8\xAF\x95.txt");
+}
+
+TEST(the_optional_language_is_accepted_and_ignored) {
+  struct http_parameter parameter;
+  char output[64];
+
+  ASSERT(
+      http_find_parameter("attachment; "
+                          "filename*=UTF-8'ja'%E3%83%86%E3%82%B9%E3%83%88.m2ts",
+                          "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+}
+
+TEST(the_utf8_charset_name_ignores_case) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=utf-8''report.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "report.txt");
+}
+
+TEST(unencoded_attribute_characters_are_preserved) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''report-1_final.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "report-1_final.txt");
+}
+
+TEST(a_percent_encoded_path_separator_is_only_decoded_here) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''dir%2Ffile.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "dir/file.txt");
+}
+
+TEST(an_unsupported_charset_is_rejected_without_output) {
+  struct http_parameter parameter;
+  char output[16] = "unchanged";
+
+  ASSERT(http_find_parameter("attachment; filename*=ISO-8859-1''report.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "unchanged");
+}
+
+TEST(an_invalid_percent_escape_is_rejected_without_output) {
+  struct http_parameter parameter;
+  char output[16] = "unchanged";
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''bad%ZZ.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "unchanged");
+}
+
+TEST(a_truncated_percent_escape_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''bad%2", "filename*",
+                             &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_percent_encoded_nul_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''a%00b.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(an_overlong_utf8_sequence_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%C0%AF.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_utf8_surrogate_sequence_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%ED%A0%80.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_four_byte_utf8_sequence_is_accepted) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%F0%9F%98%80.txt",
+                             "filename*", &parameter));
+  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
+  CHECK_STR(output, "\xF0\x9F\x98\x80.txt");
+}
+
+TEST(a_truncated_utf8_sequence_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%E3%83", "filename*",
+                             &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_codepoint_beyond_the_unicode_range_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%F4%90%80%80.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_quoted_extended_value_is_rejected) {
+  struct http_parameter parameter;
+  char output[16];
+
+  ASSERT(http_find_parameter("attachment; filename*=\"UTF-8''report.txt\"",
+                             "filename*", &parameter));
+  ASSERT(parameter.quoted);
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(a_raw_space_in_an_extended_value_is_rejected) {
+  struct http_parameter parameter;
+  char output[32];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''two words.txt",
+                             "filename*", &parameter));
+  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+}
+
+TEST(an_extended_value_needs_room_for_its_final_nul) {
+  struct http_parameter parameter;
+  char too_small[5] = "keep";
+  char exact[sizeof("a.txt")];
+
+  ASSERT(http_find_parameter("attachment; filename*=UTF-8''a.txt", "filename*",
+                             &parameter));
+  ASSERT(!http_decode_extended_parameter(too_small, sizeof(too_small),
+                                         &parameter));
+  CHECK_STR(too_small, "keep");
+  ASSERT(http_decode_extended_parameter(exact, sizeof(exact), &parameter));
+  CHECK_STR(exact, "a.txt");
+}
+
 int main(void) {
   REGISTER_DESC(an_unquoted_parameter_is_found_and_copied,
                 "an unquoted parameter is found and copied");
@@ -186,6 +380,44 @@ int main(void) {
                 "a small destination is rejected without partial output");
   REGISTER_DESC(a_destination_with_exactly_enough_space_is_accepted,
                 "a destination with room for the final NUL is accepted");
+  REGISTER_DESC(a_utf8_extended_parameter_is_percent_decoded,
+                "a UTF-8 extended parameter is percent-decoded");
+  REGISTER_DESC(a_two_byte_utf8_character_is_percent_decoded,
+                "a two-byte UTF-8 character is percent-decoded");
+  REGISTER_DESC(a_chinese_filename_is_percent_decoded,
+                "a Chinese filename and language tag are decoded");
+  REGISTER_DESC(the_optional_language_is_accepted_and_ignored,
+                "the optional language is accepted and ignored");
+  REGISTER_DESC(the_utf8_charset_name_ignores_case,
+                "the UTF-8 charset name ignores case");
+  REGISTER_DESC(unencoded_attribute_characters_are_preserved,
+                "unencoded attribute characters are preserved");
+  REGISTER_DESC(a_percent_encoded_path_separator_is_only_decoded_here,
+                "a percent-encoded path separator is only decoded here");
+  REGISTER_DESC(an_unsupported_charset_is_rejected_without_output,
+                "an unsupported charset is rejected without output");
+  REGISTER_DESC(an_invalid_percent_escape_is_rejected_without_output,
+                "an invalid percent escape is rejected without output");
+  REGISTER_DESC(a_truncated_percent_escape_is_rejected,
+                "a truncated percent escape is rejected");
+  REGISTER_DESC(a_percent_encoded_nul_is_rejected,
+                "a percent-encoded NUL is rejected");
+  REGISTER_DESC(an_overlong_utf8_sequence_is_rejected,
+                "an overlong UTF-8 sequence is rejected");
+  REGISTER_DESC(a_utf8_surrogate_sequence_is_rejected,
+                "a UTF-8 surrogate sequence is rejected");
+  REGISTER_DESC(a_four_byte_utf8_sequence_is_accepted,
+                "a four-byte UTF-8 sequence is accepted");
+  REGISTER_DESC(a_truncated_utf8_sequence_is_rejected,
+                "a truncated UTF-8 sequence is rejected");
+  REGISTER_DESC(a_codepoint_beyond_the_unicode_range_is_rejected,
+                "a codepoint beyond the Unicode range is rejected");
+  REGISTER_DESC(a_quoted_extended_value_is_rejected,
+                "a quoted extended value is rejected");
+  REGISTER_DESC(a_raw_space_in_an_extended_value_is_rejected,
+                "a raw space in an extended value is rejected");
+  REGISTER_DESC(an_extended_value_needs_room_for_its_final_nul,
+                "an extended value needs room for its final NUL");
 
   RUN_ALL();
   return DONE();

--- a/test/http_params.c
+++ b/test/http_params.c
@@ -12,517 +12,585 @@
 
 /* Finding and copying ordinary parameters. */
 
-TEST(an_unquoted_parameter_is_found_and_copied) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(an_unquoted_parameter_is_found_and_copied)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
-                             &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "a.txt");
-  CHECK(!parameter.quoted);
-  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "a.txt");
+	ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+				   &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "a.txt");
+	CHECK(!parameter.quoted);
+	ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "a.txt");
 }
 
-TEST(a_quoted_parameter_is_found_without_its_quotes) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_quoted_parameter_is_found_without_its_quotes)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename=\"a.txt\"", "filename",
-                             &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "a.txt");
-  CHECK(parameter.quoted);
-  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "a.txt");
+	ASSERT(http_find_parameter("attachment; filename=\"a.txt\"", "filename",
+				   &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "a.txt");
+	CHECK(parameter.quoted);
+	ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "a.txt");
 }
 
-TEST(parameter_names_ignore_case_and_surrounding_space) {
-  struct http_parameter parameter;
+TEST(parameter_names_ignore_case_and_surrounding_space)
+{
+	struct http_parameter parameter;
 
-  ASSERT(http_find_parameter("attachment ; FiLeNaMe \t= \t\"report.txt\"",
-                             "filename", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "report.txt");
-  CHECK(parameter.quoted);
+	ASSERT(http_find_parameter("attachment ; FiLeNaMe \t= \t\"report.txt\"",
+				   "filename", &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "report.txt");
+	CHECK(parameter.quoted);
 }
 
-TEST(a_parameter_name_must_match_in_full) {
-  struct http_parameter parameter;
+TEST(a_parameter_name_must_match_in_full)
+{
+	struct http_parameter parameter;
 
-  ASSERT(
-      http_find_parameter("attachment; xfilename=wrong-1; filename*=wrong-2; "
-                          "filename=right.txt",
-                          "filename", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "right.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; xfilename=wrong-1; filename*=wrong-2; "
+		"filename=right.txt", "filename", &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "right.txt");
 }
 
-TEST(an_extended_parameter_is_returned_in_its_raw_form) {
-  struct http_parameter parameter;
+TEST(an_extended_parameter_is_returned_in_its_raw_form)
+{
+	struct http_parameter parameter;
 
-  ASSERT(http_find_parameter("attachment; filename=a.txt; "
-                             "filename*=UTF-8''%E6%B5%8B%E8%AF%95.txt",
-                             "filename*", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length,
-             "UTF-8''%E6%B5%8B%E8%AF%95.txt");
-  CHECK(!parameter.quoted);
+	ASSERT(http_find_parameter("attachment; filename=a.txt; "
+				   "filename*=UTF-8''%E6%B5%8B%E8%AF%95.txt",
+				   "filename*", &parameter));
+	CHECK_LSTR(parameter.value, parameter.length,
+		   "UTF-8''%E6%B5%8B%E8%AF%95.txt");
+	CHECK(!parameter.quoted);
 }
 
-TEST(a_broken_segment_before_the_parameter_is_skipped) {
-  struct http_parameter parameter;
+TEST(a_broken_segment_before_the_parameter_is_skipped)
+{
+	struct http_parameter parameter;
 
-  ASSERT(http_find_parameter("attachment; broken; filename=right.txt",
-                             "filename", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "right.txt");
+	ASSERT(http_find_parameter("attachment; broken; filename=right.txt",
+				   "filename", &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "right.txt");
 }
 
 /* Quoted-string delimiters and quoted-pairs. */
 
-TEST(a_semicolon_inside_quotes_belongs_to_the_value) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_semicolon_inside_quotes_belongs_to_the_value)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename=\"a;b.txt\"; size=123",
-                             "filename", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "a;b.txt");
-  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "a;b.txt");
+	ASSERT(http_find_parameter("attachment; filename=\"a;b.txt\"; size=123",
+				   "filename", &parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "a;b.txt");
+	ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "a;b.txt");
 }
 
-TEST(quoted_pairs_are_unescaped_when_the_value_is_copied) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(quoted_pairs_are_unescaped_when_the_value_is_copied)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename=\"say \\\"hello\\\".txt\"",
-                             "filename", &parameter));
-  CHECK_LSTR(parameter.value, parameter.length, "say \\\"hello\\\".txt");
-  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "say \"hello\".txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename=\"say \\\"hello\\\".txt\"", "filename",
+		&parameter));
+	CHECK_LSTR(parameter.value, parameter.length, "say \\\"hello\\\".txt");
+	ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "say \"hello\".txt");
 }
 
-TEST(an_unclosed_quoted_value_is_rejected) {
-  struct http_parameter parameter;
+TEST(an_unclosed_quoted_value_is_rejected)
+{
+	struct http_parameter parameter;
 
-  ASSERT(!http_find_parameter("attachment; filename=\"unterminated.txt",
-                              "filename", &parameter));
+	ASSERT(!http_find_parameter("attachment; filename=\"unterminated.txt",
+				    "filename", &parameter));
 }
 
-TEST(non_space_after_a_closing_quote_invalidates_the_parameter) {
-  struct http_parameter parameter;
+TEST(non_space_after_a_closing_quote_invalidates_the_parameter)
+{
+	struct http_parameter parameter;
 
-  ASSERT(!http_find_parameter("attachment; filename=\"bad.txt\"unexpected",
-                              "filename", &parameter));
+	ASSERT(!http_find_parameter
+	       ("attachment; filename=\"bad.txt\"unexpected", "filename",
+		&parameter));
 }
 
 /* Bounds and failure behaviour. */
 
-TEST(a_parameter_search_stops_at_the_end_of_the_header_line) {
-  struct http_parameter parameter;
+TEST(a_parameter_search_stops_at_the_end_of_the_header_line)
+{
+	struct http_parameter parameter;
 
-  ASSERT(!http_find_parameter(
-      "attachment; size=123\r\n"
-      "Content-Disposition: attachment; filename=next-line.txt\r\n",
-      "filename", &parameter));
+	ASSERT(!http_find_parameter("attachment; size=123\r\n"
+				    "Content-Disposition: attachment; filename=next-line.txt\r\n",
+				    "filename", &parameter));
 }
 
-TEST(a_missing_parameter_leaves_the_result_structure_unchanged) {
-  static const char marker[] = "unchanged";
-  struct http_parameter parameter = {
-      .value = marker,
-      .length = sizeof(marker) - 1,
-      .quoted = true,
-  };
+TEST(a_missing_parameter_leaves_the_result_structure_unchanged)
+{
+	static const char marker[] = "unchanged";
+	struct http_parameter parameter = {
+		.value = marker,
+		.length = sizeof(marker) - 1,
+		.quoted = true,
+	};
 
-  ASSERT(!http_find_parameter("attachment; size=123", "filename", &parameter));
-  CHECK(parameter.value == marker);
-  CHECK_EQ(parameter.length, sizeof(marker) - 1);
-  CHECK(parameter.quoted);
+	ASSERT(!http_find_parameter
+	       ("attachment; size=123", "filename", &parameter));
+	CHECK(parameter.value == marker);
+	CHECK_EQ(parameter.length, sizeof(marker) - 1);
+	CHECK(parameter.quoted);
 }
 
-TEST(a_small_destination_is_rejected_without_being_changed) {
-  struct http_parameter parameter;
-  char output[4] = "old";
+TEST(a_small_destination_is_rejected_without_being_changed)
+{
+	struct http_parameter parameter;
+	char output[4] = "old";
 
-  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
-                             &parameter));
-  ASSERT(!http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "old");
+	ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+				   &parameter));
+	ASSERT(!http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "old");
 }
 
-TEST(a_destination_with_exactly_enough_space_is_accepted) {
-  struct http_parameter parameter;
-  char output[sizeof("a.txt")];
+TEST(a_destination_with_exactly_enough_space_is_accepted)
+{
+	struct http_parameter parameter;
+	char output[sizeof("a.txt")];
 
-  ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
-                             &parameter));
-  ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "a.txt");
+	ASSERT(http_find_parameter("attachment; filename=a.txt", "filename",
+				   &parameter));
+	ASSERT(http_copy_parameter(output, sizeof(output), &parameter));
+	CHECK_STR(output, "a.txt");
 }
 
 /* RFC 8187 extended parameter decoding. */
 
-TEST(a_utf8_extended_parameter_is_percent_decoded) {
-  struct http_parameter parameter;
-  char output[64];
+TEST(a_utf8_extended_parameter_is_percent_decoded)
+{
+	struct http_parameter parameter;
+	char output[64];
 
-  ASSERT(
-      http_find_parameter("attachment; "
-                          "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts",
-                          "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+	ASSERT(http_find_parameter("attachment; "
+				   "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts",
+				   "filename*", &parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
 }
 
-TEST(a_two_byte_utf8_character_is_percent_decoded) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_two_byte_utf8_character_is_percent_decoded)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8'fr'caf%C3%A9.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "caf\xC3\xA9.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8'fr'caf%C3%A9.txt", "filename*",
+		&parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "caf\xC3\xA9.txt");
 }
 
-TEST(a_chinese_filename_is_percent_decoded) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_chinese_filename_is_percent_decoded)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; "
-                             "filename*=UTF-8'zh-CN'%E6%B5%8B%E8%AF%95.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "\xE6\xB5\x8B\xE8\xAF\x95.txt");
+	ASSERT(http_find_parameter("attachment; "
+				   "filename*=UTF-8'zh-CN'%E6%B5%8B%E8%AF%95.txt",
+				   "filename*", &parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "\xE6\xB5\x8B\xE8\xAF\x95.txt");
 }
 
-TEST(the_optional_language_is_accepted_and_ignored) {
-  struct http_parameter parameter;
-  char output[64];
+TEST(the_optional_language_is_accepted_and_ignored)
+{
+	struct http_parameter parameter;
+	char output[64];
 
-  ASSERT(
-      http_find_parameter("attachment; "
-                          "filename*=UTF-8'ja'%E3%83%86%E3%82%B9%E3%83%88.m2ts",
-                          "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+	ASSERT(http_find_parameter("attachment; "
+				   "filename*=UTF-8'ja'%E3%83%86%E3%82%B9%E3%83%88.m2ts",
+				   "filename*", &parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
 }
 
-TEST(the_utf8_charset_name_ignores_case) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(the_utf8_charset_name_ignores_case)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=utf-8''report.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "report.txt");
+	ASSERT(http_find_parameter("attachment; filename*=utf-8''report.txt",
+				   "filename*", &parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "report.txt");
 }
 
-TEST(unencoded_attribute_characters_are_preserved) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(unencoded_attribute_characters_are_preserved)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''report-1_final.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "report-1_final.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''report-1_final.txt", "filename*",
+		&parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "report-1_final.txt");
 }
 
-TEST(a_percent_encoded_path_separator_is_only_decoded_here) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_percent_encoded_path_separator_is_only_decoded_here)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''dir%2Ffile.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "dir/file.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''dir%2Ffile.txt", "filename*",
+		&parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "dir/file.txt");
 }
 
-TEST(an_unsupported_charset_is_rejected_without_output) {
-  struct http_parameter parameter;
-  char output[16] = "unchanged";
+TEST(an_unsupported_charset_is_rejected_without_output)
+{
+	struct http_parameter parameter;
+	char output[16] = "unchanged";
 
-  ASSERT(http_find_parameter("attachment; filename*=ISO-8859-1''report.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "unchanged");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=ISO-8859-1''report.txt", "filename*",
+		&parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "unchanged");
 }
 
-TEST(an_invalid_percent_escape_is_rejected_without_output) {
-  struct http_parameter parameter;
-  char output[16] = "unchanged";
+TEST(an_invalid_percent_escape_is_rejected_without_output)
+{
+	struct http_parameter parameter;
+	char output[16] = "unchanged";
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''bad%ZZ.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "unchanged");
+	ASSERT(http_find_parameter("attachment; filename*=UTF-8''bad%ZZ.txt",
+				   "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "unchanged");
 }
 
-TEST(a_truncated_percent_escape_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_truncated_percent_escape_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''bad%2", "filename*",
-                             &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''bad%2", "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_percent_encoded_nul_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_percent_encoded_nul_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''a%00b.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter("attachment; filename*=UTF-8''a%00b.txt",
+				   "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(an_overlong_utf8_sequence_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(an_overlong_utf8_sequence_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%C0%AF.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter("attachment; filename*=UTF-8''%C0%AF.txt",
+				   "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_utf8_surrogate_sequence_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_utf8_surrogate_sequence_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%ED%A0%80.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter("attachment; filename*=UTF-8''%ED%A0%80.txt",
+				   "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_four_byte_utf8_sequence_is_accepted) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_four_byte_utf8_sequence_is_accepted)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%F0%9F%98%80.txt",
-                             "filename*", &parameter));
-  ASSERT(http_decode_extended_parameter(output, sizeof(output), &parameter));
-  CHECK_STR(output, "\xF0\x9F\x98\x80.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''%F0%9F%98%80.txt", "filename*",
+		&parameter));
+	ASSERT(http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
+	CHECK_STR(output, "\xF0\x9F\x98\x80.txt");
 }
 
-TEST(a_truncated_utf8_sequence_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_truncated_utf8_sequence_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%E3%83", "filename*",
-                             &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''%E3%83", "filename*",
+		&parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_codepoint_beyond_the_unicode_range_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_codepoint_beyond_the_unicode_range_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''%F4%90%80%80.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''%F4%90%80%80.txt", "filename*",
+		&parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_quoted_extended_value_is_rejected) {
-  struct http_parameter parameter;
-  char output[16];
+TEST(a_quoted_extended_value_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[16];
 
-  ASSERT(http_find_parameter("attachment; filename*=\"UTF-8''report.txt\"",
-                             "filename*", &parameter));
-  ASSERT(parameter.quoted);
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=\"UTF-8''report.txt\"", "filename*",
+		&parameter));
+	ASSERT(parameter.quoted);
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(a_raw_space_in_an_extended_value_is_rejected) {
-  struct http_parameter parameter;
-  char output[32];
+TEST(a_raw_space_in_an_extended_value_is_rejected)
+{
+	struct http_parameter parameter;
+	char output[32];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''two words.txt",
-                             "filename*", &parameter));
-  ASSERT(!http_decode_extended_parameter(output, sizeof(output), &parameter));
+	ASSERT(http_find_parameter("attachment; filename*=UTF-8''two words.txt",
+				   "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (output, sizeof(output), &parameter));
 }
 
-TEST(an_extended_value_needs_room_for_its_final_nul) {
-  struct http_parameter parameter;
-  char too_small[5] = "keep";
-  char exact[sizeof("a.txt")];
+TEST(an_extended_value_needs_room_for_its_final_nul)
+{
+	struct http_parameter parameter;
+	char too_small[5] = "keep";
+	char exact[sizeof("a.txt")];
 
-  ASSERT(http_find_parameter("attachment; filename*=UTF-8''a.txt", "filename*",
-                             &parameter));
-  ASSERT(!http_decode_extended_parameter(too_small, sizeof(too_small),
-                                         &parameter));
-  CHECK_STR(too_small, "keep");
-  ASSERT(http_decode_extended_parameter(exact, sizeof(exact), &parameter));
-  CHECK_STR(exact, "a.txt");
+	ASSERT(http_find_parameter
+	       ("attachment; filename*=UTF-8''a.txt", "filename*", &parameter));
+	ASSERT(!http_decode_extended_parameter
+	       (too_small, sizeof(too_small), &parameter));
+	CHECK_STR(too_small, "keep");
+	ASSERT(http_decode_extended_parameter
+	       (exact, sizeof(exact), &parameter));
+	CHECK_STR(exact, "a.txt");
 }
 
 /* Content-Disposition filename selection and sanitization. */
 
-TEST(an_extended_filename_is_preferred_over_the_legacy_fallback) {
-  char output[64];
+TEST(an_extended_filename_is_preferred_over_the_legacy_fallback)
+{
+	char output[64];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; filename=\"????????.m2ts\"; "
-      "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts",
-      output, sizeof(output)));
-  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=\"????????.m2ts\"; "
+		"filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts", output,
+		sizeof(output)));
+	CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
 }
 
-TEST(an_invalid_extended_filename_falls_back_to_filename) {
-  char output[32];
+TEST(an_invalid_extended_filename_falls_back_to_filename)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; filename=\"fallback.txt\"; "
-      "filename*=UTF-8''bad%ZZ.txt",
-      output, sizeof(output)));
-  CHECK_STR(output, "fallback.txt");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=\"fallback.txt\"; "
+		"filename*=UTF-8''bad%ZZ.txt", output, sizeof(output)));
+	CHECK_STR(output, "fallback.txt");
 }
 
-TEST(an_unsupported_extended_charset_falls_back_to_filename) {
-  char output[32];
+TEST(an_unsupported_extended_charset_falls_back_to_filename)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; filename=\"fallback.txt\"; "
-      "filename*=ISO-8859-1''report.txt",
-      output, sizeof(output)));
-  CHECK_STR(output, "fallback.txt");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=\"fallback.txt\"; "
+		"filename*=ISO-8859-1''report.txt", output, sizeof(output)));
+	CHECK_STR(output, "fallback.txt");
 }
 
-TEST(a_legacy_filename_is_used_when_no_extended_one_exists) {
-  char output[32];
+TEST(a_legacy_filename_is_used_when_no_extended_one_exists)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename("attachment; filename=\"a;b.txt\"",
-                                           output, sizeof(output)));
-  CHECK_STR(output, "a;b.txt");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=\"a;b.txt\"", output, sizeof(output)));
+	CHECK_STR(output, "a;b.txt");
 }
 
-TEST(decoded_separators_and_control_characters_are_sanitized) {
-  char output[32];
+TEST(decoded_separators_and_control_characters_are_sanitized)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; "
-      "filename*=UTF-8''dir%2Fline%0Abad%3F.txt",
-      output, sizeof(output)));
-  CHECK_STR(output, "dir_line_bad_.txt");
+	ASSERT(http_content_disposition_filename("attachment; "
+						 "filename*=UTF-8''dir%2Fline%0Abad%3F.txt",
+						 output, sizeof(output)));
+	CHECK_STR(output, "dir_line_bad_.txt");
 }
 
-TEST(a_legacy_filename_is_sanitized_after_quoted_pair_copying) {
-  char output[32];
+TEST(a_legacy_filename_is_sanitized_after_quoted_pair_copying)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; filename=\"dir\\\\file?.txt\"", output, sizeof(output)));
-  CHECK_STR(output, "dir_file_.txt");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=\"dir\\\\file?.txt\"", output,
+		sizeof(output)));
+	CHECK_STR(output, "dir_file_.txt");
 }
 
-TEST(an_unusable_extended_filename_falls_back_to_filename) {
-  char output[32];
+TEST(an_unusable_extended_filename_falls_back_to_filename)
+{
+	char output[32];
 
-  ASSERT(http_content_disposition_filename(
-      "attachment; filename=safe.txt; filename*=UTF-8''..", output,
-      sizeof(output)));
-  CHECK_STR(output, "safe.txt");
+	ASSERT(http_content_disposition_filename
+	       ("attachment; filename=safe.txt; filename*=UTF-8''..", output,
+		sizeof(output)));
+	CHECK_STR(output, "safe.txt");
 }
 
-TEST(an_extended_filename_too_large_for_the_buffer_falls_back) {
-  char output[sizeof("a.txt")];
+TEST(an_extended_filename_too_large_for_the_buffer_falls_back)
+{
+	char output[sizeof("a.txt")];
 
-  ASSERT(
-      http_content_disposition_filename("attachment; filename=a.txt; "
-                                        "filename*=UTF-8''a-very-long-name.txt",
-                                        output, sizeof(output)));
-  CHECK_STR(output, "a.txt");
+	ASSERT(http_content_disposition_filename("attachment; filename=a.txt; "
+						 "filename*=UTF-8''a-very-long-name.txt",
+						 output, sizeof(output)));
+	CHECK_STR(output, "a.txt");
 }
 
-TEST(no_usable_filename_clears_an_old_result) {
-  char output[32] = "old-response.txt";
+TEST(no_usable_filename_clears_an_old_result)
+{
+	char output[32] = "old-response.txt";
 
-  ASSERT(!http_content_disposition_filename("attachment; size=123", output,
-                                            sizeof(output)));
-  CHECK_STR(output, "");
+	ASSERT(!http_content_disposition_filename
+	       ("attachment; size=123", output, sizeof(output)));
+	CHECK_STR(output, "");
 }
 
-int main(void) {
-  REGISTER_DESC(an_unquoted_parameter_is_found_and_copied,
-                "an unquoted parameter is found and copied");
-  REGISTER_DESC(a_quoted_parameter_is_found_without_its_quotes,
-                "a quoted parameter is returned without its quotes");
-  REGISTER_DESC(parameter_names_ignore_case_and_surrounding_space,
-                "parameter names ignore case and surrounding space");
-  REGISTER_DESC(a_parameter_name_must_match_in_full,
-                "a parameter name has to match in full");
-  REGISTER_DESC(an_extended_parameter_is_returned_in_its_raw_form,
-                "an extended parameter is returned without decoding");
-  REGISTER_DESC(a_broken_segment_before_the_parameter_is_skipped,
-                "a broken segment before a parameter is skipped");
-  REGISTER_DESC(a_semicolon_inside_quotes_belongs_to_the_value,
-                "a semicolon inside quotes belongs to the value");
-  REGISTER_DESC(quoted_pairs_are_unescaped_when_the_value_is_copied,
-                "quoted-pairs are unescaped when copied");
-  REGISTER_DESC(an_unclosed_quoted_value_is_rejected,
-                "an unclosed quoted value is rejected");
-  REGISTER_DESC(non_space_after_a_closing_quote_invalidates_the_parameter,
-                "non-space after a closing quote invalidates the parameter");
-  REGISTER_DESC(a_parameter_search_stops_at_the_end_of_the_header_line,
-                "a parameter search does not cross the header line");
-  REGISTER_DESC(a_missing_parameter_leaves_the_result_structure_unchanged,
-                "a failed search leaves its result structure unchanged");
-  REGISTER_DESC(a_small_destination_is_rejected_without_being_changed,
-                "a small destination is rejected without partial output");
-  REGISTER_DESC(a_destination_with_exactly_enough_space_is_accepted,
-                "a destination with room for the final NUL is accepted");
-  REGISTER_DESC(a_utf8_extended_parameter_is_percent_decoded,
-                "a UTF-8 extended parameter is percent-decoded");
-  REGISTER_DESC(a_two_byte_utf8_character_is_percent_decoded,
-                "a two-byte UTF-8 character is percent-decoded");
-  REGISTER_DESC(a_chinese_filename_is_percent_decoded,
-                "a Chinese filename and language tag are decoded");
-  REGISTER_DESC(the_optional_language_is_accepted_and_ignored,
-                "the optional language is accepted and ignored");
-  REGISTER_DESC(the_utf8_charset_name_ignores_case,
-                "the UTF-8 charset name ignores case");
-  REGISTER_DESC(unencoded_attribute_characters_are_preserved,
-                "unencoded attribute characters are preserved");
-  REGISTER_DESC(a_percent_encoded_path_separator_is_only_decoded_here,
-                "a percent-encoded path separator is only decoded here");
-  REGISTER_DESC(an_unsupported_charset_is_rejected_without_output,
-                "an unsupported charset is rejected without output");
-  REGISTER_DESC(an_invalid_percent_escape_is_rejected_without_output,
-                "an invalid percent escape is rejected without output");
-  REGISTER_DESC(a_truncated_percent_escape_is_rejected,
-                "a truncated percent escape is rejected");
-  REGISTER_DESC(a_percent_encoded_nul_is_rejected,
-                "a percent-encoded NUL is rejected");
-  REGISTER_DESC(an_overlong_utf8_sequence_is_rejected,
-                "an overlong UTF-8 sequence is rejected");
-  REGISTER_DESC(a_utf8_surrogate_sequence_is_rejected,
-                "a UTF-8 surrogate sequence is rejected");
-  REGISTER_DESC(a_four_byte_utf8_sequence_is_accepted,
-                "a four-byte UTF-8 sequence is accepted");
-  REGISTER_DESC(a_truncated_utf8_sequence_is_rejected,
-                "a truncated UTF-8 sequence is rejected");
-  REGISTER_DESC(a_codepoint_beyond_the_unicode_range_is_rejected,
-                "a codepoint beyond the Unicode range is rejected");
-  REGISTER_DESC(a_quoted_extended_value_is_rejected,
-                "a quoted extended value is rejected");
-  REGISTER_DESC(a_raw_space_in_an_extended_value_is_rejected,
-                "a raw space in an extended value is rejected");
-  REGISTER_DESC(an_extended_value_needs_room_for_its_final_nul,
-                "an extended value needs room for its final NUL");
+int
+main(void)
+{
+	REGISTER_DESC(an_unquoted_parameter_is_found_and_copied,
+		      "an unquoted parameter is found and copied");
+	REGISTER_DESC(a_quoted_parameter_is_found_without_its_quotes,
+		      "a quoted parameter is returned without its quotes");
+	REGISTER_DESC(parameter_names_ignore_case_and_surrounding_space,
+		      "parameter names ignore case and surrounding space");
+	REGISTER_DESC(a_parameter_name_must_match_in_full,
+		      "a parameter name has to match in full");
+	REGISTER_DESC(an_extended_parameter_is_returned_in_its_raw_form,
+		      "an extended parameter is returned without decoding");
+	REGISTER_DESC(a_broken_segment_before_the_parameter_is_skipped,
+		      "a broken segment before a parameter is skipped");
+	REGISTER_DESC(a_semicolon_inside_quotes_belongs_to_the_value,
+		      "a semicolon inside quotes belongs to the value");
+	REGISTER_DESC(quoted_pairs_are_unescaped_when_the_value_is_copied,
+		      "quoted-pairs are unescaped when copied");
+	REGISTER_DESC(an_unclosed_quoted_value_is_rejected,
+		      "an unclosed quoted value is rejected");
+	REGISTER_DESC(non_space_after_a_closing_quote_invalidates_the_parameter,
+		      "non-space after a closing quote invalidates the parameter");
+	REGISTER_DESC(a_parameter_search_stops_at_the_end_of_the_header_line,
+		      "a parameter search does not cross the header line");
+	REGISTER_DESC(a_missing_parameter_leaves_the_result_structure_unchanged,
+		      "a failed search leaves its result structure unchanged");
+	REGISTER_DESC(a_small_destination_is_rejected_without_being_changed,
+		      "a small destination is rejected without partial output");
+	REGISTER_DESC(a_destination_with_exactly_enough_space_is_accepted,
+		      "a destination with room for the final NUL is accepted");
+	REGISTER_DESC(a_utf8_extended_parameter_is_percent_decoded,
+		      "a UTF-8 extended parameter is percent-decoded");
+	REGISTER_DESC(a_two_byte_utf8_character_is_percent_decoded,
+		      "a two-byte UTF-8 character is percent-decoded");
+	REGISTER_DESC(a_chinese_filename_is_percent_decoded,
+		      "a Chinese filename and language tag are decoded");
+	REGISTER_DESC(the_optional_language_is_accepted_and_ignored,
+		      "the optional language is accepted and ignored");
+	REGISTER_DESC(the_utf8_charset_name_ignores_case,
+		      "the UTF-8 charset name ignores case");
+	REGISTER_DESC(unencoded_attribute_characters_are_preserved,
+		      "unencoded attribute characters are preserved");
+	REGISTER_DESC(a_percent_encoded_path_separator_is_only_decoded_here,
+		      "a percent-encoded path separator is only decoded here");
+	REGISTER_DESC(an_unsupported_charset_is_rejected_without_output,
+		      "an unsupported charset is rejected without output");
+	REGISTER_DESC(an_invalid_percent_escape_is_rejected_without_output,
+		      "an invalid percent escape is rejected without output");
+	REGISTER_DESC(a_truncated_percent_escape_is_rejected,
+		      "a truncated percent escape is rejected");
+	REGISTER_DESC(a_percent_encoded_nul_is_rejected,
+		      "a percent-encoded NUL is rejected");
+	REGISTER_DESC(an_overlong_utf8_sequence_is_rejected,
+		      "an overlong UTF-8 sequence is rejected");
+	REGISTER_DESC(a_utf8_surrogate_sequence_is_rejected,
+		      "a UTF-8 surrogate sequence is rejected");
+	REGISTER_DESC(a_four_byte_utf8_sequence_is_accepted,
+		      "a four-byte UTF-8 sequence is accepted");
+	REGISTER_DESC(a_truncated_utf8_sequence_is_rejected,
+		      "a truncated UTF-8 sequence is rejected");
+	REGISTER_DESC(a_codepoint_beyond_the_unicode_range_is_rejected,
+		      "a codepoint beyond the Unicode range is rejected");
+	REGISTER_DESC(a_quoted_extended_value_is_rejected,
+		      "a quoted extended value is rejected");
+	REGISTER_DESC(a_raw_space_in_an_extended_value_is_rejected,
+		      "a raw space in an extended value is rejected");
+	REGISTER_DESC(an_extended_value_needs_room_for_its_final_nul,
+		      "an extended value needs room for its final NUL");
 
-  REGISTER_DESC(an_extended_filename_is_preferred_over_the_legacy_fallback,
-                "an extended filename is preferred over its legacy fallback");
-  REGISTER_DESC(an_invalid_extended_filename_falls_back_to_filename,
-                "an invalid extended filename falls back to filename");
-  REGISTER_DESC(an_unsupported_extended_charset_falls_back_to_filename,
-                "an unsupported extended charset falls back to filename");
-  REGISTER_DESC(a_legacy_filename_is_used_when_no_extended_one_exists,
-                "a legacy filename is used when no extended one exists");
-  REGISTER_DESC(decoded_separators_and_control_characters_are_sanitized,
-                "decoded separators and control characters are sanitized");
-  REGISTER_DESC(a_legacy_filename_is_sanitized_after_quoted_pair_copying,
-                "a copied legacy filename is sanitized");
-  REGISTER_DESC(an_unusable_extended_filename_falls_back_to_filename,
-                "an unusable extended filename falls back to filename");
-  REGISTER_DESC(an_extended_filename_too_large_for_the_buffer_falls_back,
-                "an oversized extended filename falls back to filename");
-  REGISTER_DESC(no_usable_filename_clears_an_old_result,
-                "no usable filename leaves an empty result");
+	REGISTER_DESC
+	    (an_extended_filename_is_preferred_over_the_legacy_fallback,
+	     "an extended filename is preferred over its legacy fallback");
+	REGISTER_DESC(an_invalid_extended_filename_falls_back_to_filename,
+		      "an invalid extended filename falls back to filename");
+	REGISTER_DESC(an_unsupported_extended_charset_falls_back_to_filename,
+		      "an unsupported extended charset falls back to filename");
+	REGISTER_DESC(a_legacy_filename_is_used_when_no_extended_one_exists,
+		      "a legacy filename is used when no extended one exists");
+	REGISTER_DESC(decoded_separators_and_control_characters_are_sanitized,
+		      "decoded separators and control characters are sanitized");
+	REGISTER_DESC(a_legacy_filename_is_sanitized_after_quoted_pair_copying,
+		      "a copied legacy filename is sanitized");
+	REGISTER_DESC(an_unusable_extended_filename_falls_back_to_filename,
+		      "an unusable extended filename falls back to filename");
+	REGISTER_DESC(an_extended_filename_too_large_for_the_buffer_falls_back,
+		      "an oversized extended filename falls back to filename");
+	REGISTER_DESC(no_usable_filename_clears_an_old_result,
+		      "no usable filename leaves an empty result");
 
-  RUN_ALL();
-  return DONE();
+	RUN_ALL();
+	return DONE();
 }

--- a/test/http_params.c
+++ b/test/http_params.c
@@ -351,6 +351,91 @@ TEST(an_extended_value_needs_room_for_its_final_nul) {
   CHECK_STR(exact, "a.txt");
 }
 
+/* Content-Disposition filename selection and sanitization. */
+
+TEST(an_extended_filename_is_preferred_over_the_legacy_fallback) {
+  char output[64];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; filename=\"????????.m2ts\"; "
+      "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts",
+      output, sizeof(output)));
+  CHECK_STR(output, "\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88.m2ts");
+}
+
+TEST(an_invalid_extended_filename_falls_back_to_filename) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; filename=\"fallback.txt\"; "
+      "filename*=UTF-8''bad%ZZ.txt",
+      output, sizeof(output)));
+  CHECK_STR(output, "fallback.txt");
+}
+
+TEST(an_unsupported_extended_charset_falls_back_to_filename) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; filename=\"fallback.txt\"; "
+      "filename*=ISO-8859-1''report.txt",
+      output, sizeof(output)));
+  CHECK_STR(output, "fallback.txt");
+}
+
+TEST(a_legacy_filename_is_used_when_no_extended_one_exists) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename("attachment; filename=\"a;b.txt\"",
+                                           output, sizeof(output)));
+  CHECK_STR(output, "a;b.txt");
+}
+
+TEST(decoded_separators_and_control_characters_are_sanitized) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; "
+      "filename*=UTF-8''dir%2Fline%0Abad%3F.txt",
+      output, sizeof(output)));
+  CHECK_STR(output, "dir_line_bad_.txt");
+}
+
+TEST(a_legacy_filename_is_sanitized_after_quoted_pair_copying) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; filename=\"dir\\\\file?.txt\"", output, sizeof(output)));
+  CHECK_STR(output, "dir_file_.txt");
+}
+
+TEST(an_unusable_extended_filename_falls_back_to_filename) {
+  char output[32];
+
+  ASSERT(http_content_disposition_filename(
+      "attachment; filename=safe.txt; filename*=UTF-8''..", output,
+      sizeof(output)));
+  CHECK_STR(output, "safe.txt");
+}
+
+TEST(an_extended_filename_too_large_for_the_buffer_falls_back) {
+  char output[sizeof("a.txt")];
+
+  ASSERT(
+      http_content_disposition_filename("attachment; filename=a.txt; "
+                                        "filename*=UTF-8''a-very-long-name.txt",
+                                        output, sizeof(output)));
+  CHECK_STR(output, "a.txt");
+}
+
+TEST(no_usable_filename_clears_an_old_result) {
+  char output[32] = "old-response.txt";
+
+  ASSERT(!http_content_disposition_filename("attachment; size=123", output,
+                                            sizeof(output)));
+  CHECK_STR(output, "");
+}
+
 int main(void) {
   REGISTER_DESC(an_unquoted_parameter_is_found_and_copied,
                 "an unquoted parameter is found and copied");
@@ -418,6 +503,25 @@ int main(void) {
                 "a raw space in an extended value is rejected");
   REGISTER_DESC(an_extended_value_needs_room_for_its_final_nul,
                 "an extended value needs room for its final NUL");
+
+  REGISTER_DESC(an_extended_filename_is_preferred_over_the_legacy_fallback,
+                "an extended filename is preferred over its legacy fallback");
+  REGISTER_DESC(an_invalid_extended_filename_falls_back_to_filename,
+                "an invalid extended filename falls back to filename");
+  REGISTER_DESC(an_unsupported_extended_charset_falls_back_to_filename,
+                "an unsupported extended charset falls back to filename");
+  REGISTER_DESC(a_legacy_filename_is_used_when_no_extended_one_exists,
+                "a legacy filename is used when no extended one exists");
+  REGISTER_DESC(decoded_separators_and_control_characters_are_sanitized,
+                "decoded separators and control characters are sanitized");
+  REGISTER_DESC(a_legacy_filename_is_sanitized_after_quoted_pair_copying,
+                "a copied legacy filename is sanitized");
+  REGISTER_DESC(an_unusable_extended_filename_falls_back_to_filename,
+                "an unusable extended filename falls back to filename");
+  REGISTER_DESC(an_extended_filename_too_large_for_the_buffer_falls_back,
+                "an oversized extended filename falls back to filename");
+  REGISTER_DESC(no_usable_filename_clears_an_old_result,
+                "no usable filename leaves an empty result");
 
   RUN_ALL();
   return DONE();


### PR DESCRIPTION
## Summary
Hi @ismaell , I think #432 along with #449 is addressed now.

- add a bounded parser for HTTP header parameters
- decode UTF-8 RFC 8187 extended parameter values
- prefer `filename*` over the legacy `filename` parameter
- fall back to `filename` when `filename*` is invalid or unusable
- sanitize decoded and legacy filenames before using them as local paths
- take `Content-Disposition` filenames only from the final HTTP response, so redirect responses cannot leave a stale filename

---
- just like #449 
```http
Content-Disposition: attachment; filename="????????.m2ts"; filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.m2ts
```
Before this change, Axel selects the fallback and creates:
________.m2ts
After this change, Axel prefers and decodes filename*, creating:
テスト.m2ts

Invalid, unsupported, oversized, or otherwise unusable extended values fall
back to the legacy filename parameter.

## Testing
- `make check TEST_SUITES='test/http_params' SH_SUITES=''`
```
Summary:
  Pass: 42
  Fail: 0
  Skip: 0
  Todo: 0
```
- `make check`
```
Summary:
  Pass: 202
  Fail: 0
  Skip: 0
  Todo: 0
```
- local end-to-end HTTP route matrix ( If the test file needed I'd like to upload them)
- 11 passed, 0 failed
- covered Chinese, Japanese, Korean, mixed-language filenames
- covered both relative orders of filename and filename*
- covered redirects ending with filename*, filename, or no filename
---
- manually tested against public HTTPS responses containing UTF-8 Chinese filenames
```
./real_test.sh 
content-disposition: attachment; filename=test.json; filename*=UTF-8''%E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95.json
content-disposition: attachment; filename=report.json; filename*=UTF-8''%E5%B9%B4%E5%BA%A6%E6%8A%A5%E5%91%8A.json
content-disposition: attachment; filename=readme.json; filename*=UTF-8''%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E.json
========= PRE AXEL BEHAVIOR =========
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dtest.js
on%3B%20filename*%3DUTF-8''%25E4%25B8%25AD%25E6%2596%2587%25E6%25B5%258B%25E8%25AF%2595.json
File size: 195 byte(s) (195 bytes)
Opening output file test.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 176.0B/s]

Downloaded 195 byte(s) in 1 second(s). (0.17 KB/s)
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dreport.
json%3B%20filename*%3DUTF-8''%25E5%25B9%25B4%25E5%25BA%25A6%25E6%258A%25A5%25E5%2591%258A.json
File size: 197 byte(s) (197 bytes)
Opening output file report.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 178.0B/s]

Downloaded 197 byte(s) in 1 second(s). (0.17 KB/s)
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dreadme.
json%3B%20filename*%3DUTF-8''%25E4%25BD%25BF%25E7%2594%25A8%25E8%25AF%25B4%25E6%2598%258E.json
File size: 197 byte(s) (197 bytes)
Opening output file readme.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 177.0B/s]

Downloaded 197 byte(s) in 1 second(s). (0.17 KB/s)
========= FIXED AXEL BEHAVIOR =========
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dtest.js
on%3B%20filename*%3DUTF-8''%25E4%25B8%25AD%25E6%2596%2587%25E6%25B5%258B%25E8%25AF%2595.json
File size: 195 byte(s) (195 bytes)
Opening output file 中文测试.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 194.0B/s]

Downloaded 195 byte(s) in 1 second(s). (0.19 KB/s)
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dreport.
json%3B%20filename*%3DUTF-8''%25E5%25B9%25B4%25E5%25BA%25A6%25E6%258A%25A5%25E5%2591%258A.json
File size: 197 byte(s) (197 bytes)
Opening output file 年度报告.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 195.0B/s]

Downloaded 197 byte(s) in 1 second(s). (0.19 KB/s)
Initializing download: https://httpbingo.org/response-headers?Content-Disposition=attachment%3B%20filename%3Dreadme.
json%3B%20filename*%3DUTF-8''%25E4%25BD%25BF%25E7%2594%25A8%25E8%25AF%25B4%25E6%2598%258E.json
File size: 197 byte(s) (197 bytes)
Opening output file 使用说明.json
Server unsupported, starting from scratch with one connection.
Starting download

[100%] [......................................................................................] [ 195.0B/s]

Downloaded 197 byte(s) in 1 second(s). (0.19 KB/s)
total 24
-rw-r--r-- 1 kyomoto kyomoto 197  8月28日 20:20 年度报告.json
-rw-r--r-- 1 kyomoto kyomoto 197  8月28日 20:20 使用说明.json
-rw-r--r-- 1 kyomoto kyomoto 195  8月28日 20:20 中文测试.json
-rw-r--r-- 1 kyomoto kyomoto 197  8月28日 20:20 readme.json
-rw-r--r-- 1 kyomoto kyomoto 197  8月28日 20:20 report.json
-rw-r--r-- 1 kyomoto kyomoto 195  8月28日 20:20 test.json
```

Fixes #432
Fixes #449